### PR TITLE
removed repeated emoji constants in EXPRESSIONS

### DIFF
--- a/src/extensions/Emoji/components/EmojiPicker/constants.ts
+++ b/src/extensions/Emoji/components/EmojiPicker/constants.ts
@@ -165,8 +165,6 @@ export const EXPRESSIONES = [
   '👄',
   '💋',
   '🩸',
-
-  '💋',
   '💌',
   '💘',
   '💝',


### PR DESCRIPTION
Fixed following error:
Warning: Encountered two children with the same key, `emoji-picker-💋`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.