### PR TITLE
feat: manually import `katex` styles

### DIFF
--- a/docs/extensions/Katex/index.md
+++ b/docs/extensions/Katex/index.md
@@ -16,6 +16,8 @@ next:
 ## Usage
 
 ```tsx
+
+import 'katex/dist/katex.min.css'; // [!code ++]
 import { Katex } from 'reactjs-tiptap-editor'; // [!code ++]
 
 const extensions = [

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -50,6 +50,7 @@ import RichTextEditor, {
 } from 'reactjs-tiptap-editor'
 
 import 'reactjs-tiptap-editor/style.css'
+import 'katex/dist/katex.min.css'
 
 function convertBase64ToBlob(base64: string) {
   const arr = base64.split(',')

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,6 +1,5 @@
-@import './global';
-@import './editor';
-@import './ProseMirror';
-@import 'katex/dist/katex.min.css';
-@import './columns.scss';
-@import './mention.scss';
+@use './global';
+@use './editor';
+@use './ProseMirror';
+@use './columns';
+@use './mention';


### PR DESCRIPTION
<img width="540" alt="image" src="https://github.com/user-attachments/assets/69f0a2dc-76bc-4249-b9e4-1782a826c23a">

Why `lib/style.css` file is so big?

> Because `@import 'katex/dist/katex.min.css';`

Let's remove this line and manually import `katex` styles by user.
