### PR TITLE
Fix DOCX table width issue by setting to 100%

### DIFF
--- a/src/extensions/ExportWord/ExportWord.ts
+++ b/src/extensions/ExportWord/ExportWord.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { Extension } from '@tiptap/core';
-import { Packer } from 'docx';
+import { Packer, WidthType } from 'docx';
 import { DocxSerializer, defaultMarks, defaultNodes } from 'prosemirror-docx';
 
 import { ActionButton } from '@/components';
@@ -29,6 +29,16 @@ const nodeSerializer = {
     // No image
     state.renderInline(node);
     state.closeBlock(node);
+  },
+  table(state: any, node: any) {
+    state.table(node, {
+      tableOptions: {
+        width: {
+          size: 100,
+          type: WidthType.PERCENTAGE,
+        },
+      },
+    });
   },
 };
 const docxSerializer = new DocxSerializer(nodeSerializer, defaultMarks);


### PR DESCRIPTION
This pull request fixes Issue #171 where DOCX tables appeared too small due to missing width settings.
The fix ensures that tables use `WidthType.PERCENTAGE` with a size of 100%, making them properly span the full width.