### PR TITLE
Add default inline config for images

### DIFF
--- a/src/extensions/Image/Image.ts
+++ b/src/extensions/Image/Image.ts
@@ -31,6 +31,7 @@ const DEFAULT_OPTIONS: any = {
   acceptMimes: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg'],
   maxSize: 1024 * 1024 * 5, // 5MB
   resourceImage: 'both',
+  defaultInline: false,
 };
 
 declare module '@tiptap/core' {
@@ -63,6 +64,7 @@ export interface IImageOptions extends GeneralOptions<IImageOptions> {
 
   /** The source URL of the image */
   resourceImage: 'upload' | 'link' | 'both'
+  defaultInline?: boolean
 }
 
 export const Image = TiptapImage.extend<IImageOptions>({
@@ -152,7 +154,10 @@ export const Image = TiptapImage.extend<IImageOptions>({
       setImageInline: (options: any) => ({ commands }: any) => {
         return commands.insertContent({
           type: this.name,
-          attrs: options,
+          attrs: {
+            ...options,
+            inline: options.inline ?? this.options.defaultInline,
+          },
         });
       },
       updateImage:

--- a/src/extensions/Image/components/ActionImageButton.tsx
+++ b/src/extensions/Image/components/ActionImageButton.tsx
@@ -15,7 +15,9 @@ function ActionImageButton(props: any) {
   const [link, setLink] = useState<string>('');
   const fileInput = useRef<HTMLInputElement>(null);
 
-  const [imageInline, setImageInline] = useState(false);
+  const [imageInline, setImageInline] = useState(props.editor.extensionManager.extensions.find(
+    (extension: any) => extension.name === Image.name,
+  )?.options.defaultInline || false);
 
   const uploadOptions = useMemo(() => {
     const uploadOptions = props.editor.extensionManager.extensions.find(


### PR DESCRIPTION
Fixes #180

Add a configuration option to set images inline by default.

* Add a new configuration option `defaultInline` to the `Image` extension in `src/extensions/Image/Image.ts`.
* Update the `setImageInline` command in `src/extensions/Image/Image.ts` to use the `defaultInline` config.
* Pre-select the inline checkbox based on the `defaultInline` config in `src/extensions/Image/components/ActionImageButton.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hunghg255/reactjs-tiptap-editor/pull/181?shareId=ebf7494c-f77b-459a-bfcc-3c3eb4d0952a).