### PR TITLE
Fix createImageUpload defaultInline prop

### DIFF
--- a/src/extensions/Image/Image.ts
+++ b/src/extensions/Image/Image.ts
@@ -270,6 +270,7 @@ export const Image = TiptapImage.extend<IImageOptions>({
       validateFn: validateFile,
       onUpload: this.options.upload as any,
       // postUpload: this.options.postUpload,
+      defaultInline: this.options.defaultInline,
     });
 
     return [


### PR DESCRIPTION
Update `createImageUpload` function to include `defaultInline` prop.

* Add `defaultInline` prop to `createImageUpload` function call in `src/extensions/Image/Image.ts`
* Keep the commented line `// postUpload: this.options.postUpload,` in `src/extensions/Image/Image.ts`

Note: my bad, I forgot to pass the property along in my previous PR

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hunghg255/reactjs-tiptap-editor/pull/186?shareId=4a5e46d3-57e5-41b0-ae32-497edde21003).