### PR TITLE
Update LinkEditBlock.tsx

### DIFF
--- a/src/extensions/Link/components/LinkEditBlock.tsx
+++ b/src/extensions/Link/components/LinkEditBlock.tsx
@@ -27,7 +27,7 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
       const { from, to } = props.editor.state.selection;
       const text = props.editor.state.doc.textBetween(from, to, ' ');
       setForm({
-        link,
+        link: link || "",
         text,
       });
       setOpenInNewTab(target === '_blank');


### PR DESCRIPTION
fix: prevent controlled-to-uncontrolled input warning in link field

When `link` is undefined, passing it to an input `value` causes a React warning about a controlled input becoming uncontrolled. Applied `link || ""` fallback to ensure the form state always contains valid strings and avoids this issue.