### PR TITLE
Fix (active video button): removed redundant validation for video url

### DIFF
--- a/src/extensions/Video/Video.ts
+++ b/src/extensions/Video/Video.ts
@@ -35,7 +35,15 @@ export interface VideoOptions extends GeneralOptions<VideoOptions> {
   upload?: (file: File) => Promise<string>
 
   /** The source URL of the video */
-  resourceVideo: 'upload' | 'link' | 'both'
+  resourceVideo: 'upload' | 'link' | 'both',
+
+  /**
+   * List of allowed video hosting providers
+   * Use ['.'] to allow any URL, or specify providers like ['youtube', 'vimeo']
+   *
+   * @default ['.']
+   */
+  videoProviders?: string[]
 }
 
 /**
@@ -119,6 +127,7 @@ export const Video = /* @__PURE__ */ Node.create<VideoOptions>({
             disabled: !editor.can().setVideo?.({}),
             icon: 'Video',
             tooltip: t('editor.video.tooltip'),
+            videoProviders: ['.'],
             editor,
           },
         };

--- a/src/extensions/Video/components/ActiveVideoButton.tsx
+++ b/src/extensions/Video/components/ActiveVideoButton.tsx
@@ -158,17 +158,7 @@ function ActionVideoButton(props: any) {
                   type="url"
                   value={link}
                   onChange={(e) => {
-                    const url = e.target.value;
-
-                    const isVideoUrl = checkIsVideo(url);
-
-                    if (!isVideoUrl) {
-                      setError('Invalid video URL');
-                      setLink('');
-                      return;
-                    }
-                    setError('');
-                    setLink(url);
+                    setLink(e.target.value);
                   }}
                 />
 


### PR DESCRIPTION
This PR should resolve #234 
This bug appears in the demo: https://reactjs-tiptap-editor-playground.vercel.app/ (Video > Link > try typing)

Fixed link validation for video URLs and added domain whitelist, similar to [Froala's implementation](https://froala.com/wysiwyg-editor/docs/options/?tp_nonce=fc89afa439&_wp_http_referer=%2Fwysiwyg-editor%2Fdocs%2Foptions%2F&s=videoAllowedProviders&post_type=page#videoallowedproviders)
So now it can be used this way:

```javascript
Video.configure({
    resourceVideo: 'link',
    videoProviders: ['youtube', 'vimeo'],
}),
```

