### PR TITLE
Add initialDisplayedColor prop to ColorActionButton and ActionButton

### DIFF
--- a/docs/extensions/Color/index.md
+++ b/docs/extensions/Color/index.md
@@ -45,3 +45,10 @@ Default: `undefined`
 ```js
 import { DEFAULT_COLOR } from 'reactjs-tiptap-editor'
 ```
+
+### initialDisplayedColor
+
+Type: `string`\
+Default: `undefined`
+
+The initial color to be displayed in the action button. If not provided, a default color will be used.

--- a/src/components/ActionButton.tsx
+++ b/src/components/ActionButton.tsx
@@ -39,6 +39,8 @@ export interface ActionButtonProps {
   asChild?: boolean
   /* Whether it's an upload button */
   upload?: boolean
+  /* Initial displayed color */
+  initialDisplayedColor?: string
 }
 
 const ActionButton = React.forwardRef<HTMLButtonElement, Partial<ActionButtonProps>>(
@@ -58,6 +60,7 @@ const ActionButton = React.forwardRef<HTMLButtonElement, Partial<ActionButtonPro
       children,
       asChild = false,
       upload = false,
+      initialDisplayedColor = undefined,
       ...rest
     } = props;
 

--- a/src/extensions/Color/components/ColorActionButton.tsx
+++ b/src/extensions/Color/components/ColorActionButton.tsx
@@ -16,6 +16,7 @@ interface ColorActionButtonProps {
   disabled?: boolean
   action?: ButtonViewReturnComponentProps['action']
   isActive?: ButtonViewReturnComponentProps['isActive']
+  initialDisplayedColor?: string
 }
 
 interface IconCProps {
@@ -81,7 +82,7 @@ function ColorActionButton(props: ColorActionButtonProps) {
     <div className="richtext-flex richtext-items-center richtext-h-[32px]">
       <ActionButton tooltip={props?.tooltip} disabled={props?.disabled} action={toggleColor}>
         <span className="richtext-flex richtext-items-center richtext-justify-center richtext-text-sm">
-          <IconC fill={selectedColor} />
+          <IconC fill={selectedColor || props.initialDisplayedColor} />
         </span>
       </ActionButton>
 


### PR DESCRIPTION
Fixes https://github.com/hunghg255/reactjs-tiptap-editor/issues/238
Not sure if it is the best solution, but should help with the customization of the initial color that appears in the color action button

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hunghg255/reactjs-tiptap-editor/pull/239?shareId=228d9a39-a48c-48cb-9565-ca106c07d2cc).