### PR TITLE
fix: fix bug page reload when click the apply button in Link Ext and put the editor in the form element.

### DIFF
--- a/src/extensions/Link/components/LinkEditBlock.tsx
+++ b/src/extensions/Link/components/LinkEditBlock.tsx
@@ -94,6 +94,7 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
         <Button
           className="richtext-mt-2 richtext-self-end"
           onClick={handleSubmit}
+          type="button"
         >
           {t("editor.link.dialog.button.apply")}
         </Button>

--- a/src/extensions/Link/components/LinkEditBlock.tsx
+++ b/src/extensions/Link/components/LinkEditBlock.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable no-unsafe-optional-chaining */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
-import { Button, IconComponent, Input, Label, Switch } from "@/components";
-import { useLocale } from "@/locales";
+import { Button, IconComponent, Input, Label, Switch } from '@/components';
+import { useLocale } from '@/locales';
 
 interface IPropsLinkEditBlock {
   editor: any;
@@ -15,22 +15,22 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
   const { t } = useLocale();
 
   const [form, setForm] = useState({
-    text: "",
-    link: "",
+    text: '',
+    link: '',
   });
   const [openInNewTab, setOpenInNewTab] = useState<boolean>(false);
 
   useEffect(() => {
     if (props?.editor) {
-      const { href: link, target } = props.editor?.getAttributes("link");
+      const { href: link, target } = props.editor?.getAttributes('link');
 
       const { from, to } = props.editor.state.selection;
-      const text = props.editor.state.doc.textBetween(from, to, " ");
+      const text = props.editor.state.doc.textBetween(from, to, ' ');
       setForm({
-        link: link || "",
+        link: link || '',
         text,
       });
-      setOpenInNewTab(target === "_blank");
+      setOpenInNewTab(target === '_blank');
     }
   }, [props?.editor]);
 
@@ -38,13 +38,15 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
     event.preventDefault();
     event.stopPropagation();
     props?.onSetLink(form.link, form.text, openInNewTab);
-    setForm({ text: "", link: "" });
+    setForm({ text: '', link: '' });
   }
 
   return (
     <div className="border-neutral-200 richtext-rounded-lg !richtext-border richtext-bg-white richtext-p-2 richtext-shadow-sm dark:richtext-border-neutral-800 dark:richtext-bg-black">
       <div className="richtext-flex richtext-flex-col richtext-gap-2">
-        <Label className="mb-[6px]">{t("editor.link.dialog.text")}</Label>
+        <Label className="mb-[6px]">
+          {t('editor.link.dialog.text')}
+        </Label>
 
         <div className="richtext-mb-[10px] richtext-flex richtext-w-full richtext-max-w-sm richtext-items-center richtext-gap-1.5">
           <div className="richtext-relative richtext-w-full richtext-max-w-sm richtext-items-center">
@@ -59,7 +61,9 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
           </div>
         </div>
 
-        <Label className="mb-[6px]">{t("editor.link.dialog.link")}</Label>
+        <Label className="mb-[6px]">
+          {t('editor.link.dialog.link')}
+        </Label>
 
         <div className="richtext-flex richtext-w-full richtext-max-w-sm richtext-items-center richtext-gap-1.5">
           <div className="richtext-relative richtext-w-full richtext-max-w-sm richtext-items-center">
@@ -81,7 +85,9 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
         </div>
 
         <div className="richtext-flex richtext-items-center richtext-space-x-2">
-          <Label>{t("editor.link.dialog.openInNewTab")}</Label>
+          <Label>
+            {t('editor.link.dialog.openInNewTab')}
+          </Label>
 
           <Switch
             checked={openInNewTab}
@@ -96,7 +102,7 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
           onClick={handleSubmit}
           type="button"
         >
-          {t("editor.link.dialog.button.apply")}
+          {t('editor.link.dialog.button.apply')}
         </Button>
       </div>
     </div>

--- a/src/extensions/Link/components/LinkEditBlock.tsx
+++ b/src/extensions/Link/components/LinkEditBlock.tsx
@@ -1,36 +1,36 @@
 /* eslint-disable no-unsafe-optional-chaining */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 
-import { Button, IconComponent, Input, Label, Switch } from '@/components';
-import { useLocale } from '@/locales';
+import { Button, IconComponent, Input, Label, Switch } from "@/components";
+import { useLocale } from "@/locales";
 
 interface IPropsLinkEditBlock {
-  editor: any
-  onSetLink: (link: string, text?: string, openInNewTab?: boolean) => void
+  editor: any;
+  onSetLink: (link: string, text?: string, openInNewTab?: boolean) => void;
 }
 
 function LinkEditBlock(props: IPropsLinkEditBlock) {
   const { t } = useLocale();
 
   const [form, setForm] = useState({
-    text: '',
-    link: '',
+    text: "",
+    link: "",
   });
   const [openInNewTab, setOpenInNewTab] = useState<boolean>(false);
 
   useEffect(() => {
     if (props?.editor) {
-      const { href: link, target } = props.editor?.getAttributes('link');
+      const { href: link, target } = props.editor?.getAttributes("link");
 
       const { from, to } = props.editor.state.selection;
-      const text = props.editor.state.doc.textBetween(from, to, ' ');
+      const text = props.editor.state.doc.textBetween(from, to, " ");
       setForm({
-        link: link || '',
+        link: link || "",
         text,
       });
-      setOpenInNewTab(target === '_blank');
+      setOpenInNewTab(target === "_blank");
     }
   }, [props?.editor]);
 
@@ -38,22 +38,19 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
     event.preventDefault();
     event.stopPropagation();
     props?.onSetLink(form.link, form.text, openInNewTab);
+    setForm({ text: "", link: "" });
   }
 
   return (
     <div className="border-neutral-200 richtext-rounded-lg !richtext-border richtext-bg-white richtext-p-2 richtext-shadow-sm dark:richtext-border-neutral-800 dark:richtext-bg-black">
-      <form className="richtext-flex richtext-flex-col richtext-gap-2"
-        onSubmit={handleSubmit}
-      >
-        <Label className="mb-[6px]">
-          {t('editor.link.dialog.text')}
-        </Label>
+      <div className="richtext-flex richtext-flex-col richtext-gap-2">
+        <Label className="mb-[6px]">{t("editor.link.dialog.text")}</Label>
 
         <div className="richtext-mb-[10px] richtext-flex richtext-w-full richtext-max-w-sm richtext-items-center richtext-gap-1.5">
           <div className="richtext-relative richtext-w-full richtext-max-w-sm richtext-items-center">
             <Input
               className="richtext-w-80"
-              onChange={e => setForm({ ...form, text: e.target.value })}
+              onChange={(e) => setForm({ ...form, text: e.target.value })}
               placeholder="Text"
               required
               type="text"
@@ -62,22 +59,21 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
           </div>
         </div>
 
-        <Label className="mb-[6px]">
-          {t('editor.link.dialog.link')}
-        </Label>
+        <Label className="mb-[6px]">{t("editor.link.dialog.link")}</Label>
 
         <div className="richtext-flex richtext-w-full richtext-max-w-sm richtext-items-center richtext-gap-1.5">
           <div className="richtext-relative richtext-w-full richtext-max-w-sm richtext-items-center">
             <Input
               className="richtext-pl-10"
-              onChange={e => setForm({ ...form, link: e.target.value })}
+              onChange={(e) => setForm({ ...form, link: e.target.value })}
               required
               type="url"
               value={form.link}
             />
 
             <span className="richtext-absolute richtext-inset-y-0 richtext-start-0 richtext-flex richtext-items-center richtext-justify-center richtext-px-2">
-              <IconComponent className="richtext-size-5 richtext-text-muted-foreground"
+              <IconComponent
+                className="richtext-size-5 richtext-text-muted-foreground"
                 name="Link"
               />
             </span>
@@ -85,9 +81,7 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
         </div>
 
         <div className="richtext-flex richtext-items-center richtext-space-x-2">
-          <Label>
-            {t('editor.link.dialog.openInNewTab')}
-          </Label>
+          <Label>{t("editor.link.dialog.openInNewTab")}</Label>
 
           <Switch
             checked={openInNewTab}
@@ -97,12 +91,13 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
           />
         </div>
 
-        <Button className="richtext-mt-2 richtext-self-end"
-          type="submit"
+        <Button
+          className="richtext-mt-2 richtext-self-end"
+          onClick={handleSubmit}
         >
-          {t('editor.link.dialog.button.apply')}
+          {t("editor.link.dialog.button.apply")}
         </Button>
-      </form>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fix: [#254](https://github.com/hunghg255/reactjs-tiptap-editor/issues/254)

Problem: push the RichTextEditor in the form element, after create a link, click text to edit link, click the appy to save edit
=> page reload

Update: 
-replace the form element in LinkEditBlock with div element, 
-add type=button to the "Apply" button
-put the onClick={handleSubmit} to the button
