### PR TITLE
fix: fix bug not fill the text link when edit link

### DIFF
--- a/src/components/menus/components/BubbleMenuLink.tsx
+++ b/src/components/menus/components/BubbleMenuLink.tsx
@@ -7,8 +7,8 @@ import LinkEditBlock from '@/extensions/Link/components/LinkEditBlock';
 import LinkViewBlock from '@/extensions/Link/components/LinkViewBlock';
 
 export interface BubbleMenuLinkProps {
-  editor: Editor
-  disabled?: boolean
+  editor: Editor;
+  disabled?: boolean;
 }
 
 function BubbleMenuLink({ editor, disabled }: BubbleMenuLinkProps) {
@@ -42,8 +42,9 @@ function BubbleMenuLink({ editor, disabled }: BubbleMenuLinkProps) {
         ],
       })
       .setLink({ href: url })
-      .focus()
+      .selectNodeForward()
       .run();
+
     setShowEdit(false);
   };
 
@@ -69,28 +70,24 @@ function BubbleMenuLink({ editor, disabled }: BubbleMenuLinkProps) {
           },
         }}
       >
-        {disabled
-          ? (
-            <></>
-          )
-          : (
-            <>
-              {showEdit
-                ? (
-                  <LinkEditBlock onSetLink={onSetLink} editor={editor} />
-                )
-                : (
-                  <LinkViewBlock
-                    editor={editor}
-                    onClear={unSetLink}
-                    onEdit={() => {
-                      setShowEdit(true);
-                    }}
-                    link={link}
-                  />
-                )}
-            </>
-          )}
+        {disabled ? (
+          <></>
+        ) : (
+          <>
+            {showEdit ? (
+              <LinkEditBlock onSetLink={onSetLink} editor={editor} />
+            ) : (
+              <LinkViewBlock
+                editor={editor}
+                onClear={unSetLink}
+                onEdit={() => {
+                  setShowEdit(true);
+                }}
+                link={link}
+              />
+            )}
+          </>
+        )}
       </BubbleMenu>
     </>
   );


### PR DESCRIPTION
Fix: [#256]
Update:
- in the BubbleMenuLink component, change from function focus to selectNodeForward. This make the cursor unfocus the the text link, and then close the small edit popup (:>>). 


Note: Please release a new version if you check it ok and add the pretier config file for the format.
