### PR TITLE
Fix: When multiple editors are present in dom, editing existing Excalidraw diagrams open multiple dialogs

### DIFF
--- a/src/components/menus/components/BubbleMenuExcalidraw.tsx
+++ b/src/components/menus/components/BubbleMenuExcalidraw.tsx
@@ -34,7 +34,7 @@ export function BubbleMenuExcalidraw({ editor }: any) {
     [editor],
   );
   const openEditLinkModal = useCallback(() => {
-    triggerOpenExcalidrawSettingModal(attrs);
+    triggerOpenExcalidrawSettingModal({ ...attrs, editor });
   }, [editor, attrs]);
   const shouldShow = useCallback(() => editor.isActive(Excalidraw.name), [editor]);
   const deleteMe = useCallback(() => deleteNode(Excalidraw.name, editor), [editor]);

--- a/src/extensions/Excalidraw/components/ExcalidrawActiveButton.tsx
+++ b/src/extensions/Excalidraw/components/ExcalidrawActiveButton.tsx
@@ -69,6 +69,8 @@ export const ExcalidrawActiveButton: React.FC<IProps> = ({ editor }) => {
 
   useEffect(() => {
     const handler = (data: any) => {
+      if (data?.editor !== editor) return; // only respond to events from the matching editor
+
       toggleVisible(true);
       data && setInitialData(data.data);
     };


### PR DESCRIPTION
Fixes the issue by only responding to the OPEN_EXCALIDRAW_SETTING_MODAL event from the correct Editor instance.