### PR TITLE
Fix: Wrong mouse cursor offset in Excalidraw

### DIFF
--- a/src/extensions/Excalidraw/components/ExcalidrawActiveButton.tsx
+++ b/src/extensions/Excalidraw/components/ExcalidrawActiveButton.tsx
@@ -82,6 +82,15 @@ export const ExcalidrawActiveButton: React.FC<IProps> = ({ editor }) => {
     };
   }, [editor, toggleVisible]);
 
+  useEffect(() => {
+    if (!loading && Excalidraw && visible) {
+      // delay to let animations & DOM settle
+      setTimeout(() => {
+        window.dispatchEvent(new Event('resize'));
+      }, 400);
+    }
+  }, [loading, Excalidraw, visible]);
+
   return (
     <Dialog
       onOpenChange={toggleVisible}


### PR DESCRIPTION
When Excalidraw canvas is drawn using the extension, it has the wrong mouse cursor offset, as the drawing canvas of Excalidraw reports wrong dimensions. The issue is common - actual reasons unknown, but most likely it has something to do with the canvas being in a Dialog that animates. See, for example, https://github.com/excalidraw/excalidraw/issues/7312

This simple patch seems to fix the issue by redrawing after a bit of delay.