### PR TITLE
fix: fix bug not fill the text link when edit link

### DIFF
--- a/src/components/menus/components/BubbleMenuLink.tsx
+++ b/src/components/menus/components/BubbleMenuLink.tsx
@@ -25,6 +25,12 @@ function BubbleMenuLink({ editor, disabled }: BubbleMenuLinkProps) {
   }, []);
 
   const onSetLink = (url: string, text?: string, openInNewTab?: boolean) => {
+    const selection = editor.state.selection;
+    const { from } = selection;
+
+    const insertedLength = text?.length ?? 0;
+    const newTo = from + insertedLength;
+
     editor
       .chain()
       .extendMarkRange('link')
@@ -42,7 +48,8 @@ function BubbleMenuLink({ editor, disabled }: BubbleMenuLinkProps) {
         ],
       })
       .setLink({ href: url })
-      .selectNodeForward()
+      .setTextSelection({ from, to: newTo }) // 👈 Select inserted text
+      .focus()
       .run();
 
     setShowEdit(false);

--- a/src/extensions/Link/Link.ts
+++ b/src/extensions/Link/Link.ts
@@ -7,7 +7,9 @@ import type { EditorView } from '@tiptap/pm/view';
 import LinkEditPopover from '@/extensions/Link/components/LinkEditPopover';
 import type { GeneralOptions } from '@/types';
 
-export interface LinkOptions extends TiptapLinkOptions, GeneralOptions<LinkOptions> {}
+export interface LinkOptions
+  extends TiptapLinkOptions,
+  GeneralOptions<LinkOptions> {}
 
 export const Link = /* @__PURE__ */ TiptapLink.extend<LinkOptions>({
   inclusive: false,
@@ -39,6 +41,12 @@ export const Link = /* @__PURE__ */ TiptapLink.extend<LinkOptions>({
             editor,
             action: (value) => {
               const { link, text, openInNewTab } = value;
+
+              const { state } = editor;
+              const { from } = state.selection;
+              const insertedLength = text.length;
+              const to = from + insertedLength;
+
               editor
                 .chain()
                 .extendMarkRange('link')
@@ -56,6 +64,7 @@ export const Link = /* @__PURE__ */ TiptapLink.extend<LinkOptions>({
                   ],
                 })
                 .setLink({ href: link })
+                .setTextSelection({ from, to }) // 👈 Select inserted text
                 .focus()
                 .run();
             },
@@ -82,7 +91,9 @@ export const Link = /* @__PURE__ */ TiptapLink.extend<LinkOptions>({
             }
             const $start = doc.resolve(range.from);
             const $end = doc.resolve(range.to);
-            const transaction = tr.setSelection(new TextSelection($start, $end));
+            const transaction = tr.setSelection(
+              new TextSelection($start, $end)
+            );
             view.dispatch(transaction);
           },
         },


### PR DESCRIPTION
Fix: [#256 ]
After i update the lib in my project, it still dont work in some case.
Update: Now the strategy is not close the popup, instead, we reselect the whole word, that make sure the text was get correctly. 
Note: Please release new version.