### PR TITLE
fix: iframe not taking full height

### DIFF
--- a/src/styles/ProseMirror.scss
+++ b/src/styles/ProseMirror.scss
@@ -74,7 +74,7 @@
   }
   iframe {
     @apply richtext-border !important;
-    @apply richtext-w-full richtext-border-border richtext-mt-2 richtext-rounded-sm richtext-h-[400px];
+    @apply richtext-w-full richtext-border-border richtext-mt-2 richtext-rounded-sm richtext-h-full;
   }
 
   [data-type='horizontalRule'] {


### PR DESCRIPTION
This PR updates the default styling for iframes to allow them to scale with their parent container, instead of using a fixed height of 400 pixels.

May be related to #204 

Before:
<img width="801" height="871" alt="Screenshot 2025-07-14 175635" src="https://github.com/user-attachments/assets/8f414d2e-0076-40b1-a9cd-c7fe784b8926" />

After (iframe takes full height of container):
<img width="811" height="1062" alt="Screenshot 2025-07-14 175534" src="https://github.com/user-attachments/assets/69315d20-5d47-40a8-bbd9-83b3a15b4cb3" />


