### PR TITLE
fix(link): resolve issues with HTMLAttributes and bubble popup update

### DIFF
--- a/src/extensions/Link/Link.ts
+++ b/src/extensions/Link/Link.ts
@@ -101,3 +101,5 @@ export const Link = /* @__PURE__ */ TiptapLink.extend<LinkOptions>({
     ];
   },
 });
+
+export default Link;


### PR DESCRIPTION
- Fixed the problem that the HTMLAttributes configuration of the link component does not take effect.
- Fixed the problem that when changing the link bubble pop-up window display, switching to other links, the bubble pop-up window data is not updated.