### PR TITLE
feat(export-pdf): allow customization for ExportPdf extension via ExportPdfOptions

### DIFF
--- a/docs/extensions/ExportPdf/index.md
+++ b/docs/extensions/ExportPdf/index.md
@@ -21,3 +21,121 @@ const extensions = [
    ExportPdf, // [!code ++]
 ];
 ```
+
+Here’s the documentation in the same style:
+
+---
+
+## Options
+
+### paperSize
+
+Type: `PaperSize`
+Default: `'Letter'`
+
+Specifies the size of the paper used when exporting to PDF.
+
+Supported values:
+
+```ts
+type PaperSize =
+  | 'Legal'
+  | 'Letter'
+  | 'Tabloid'
+  | 'A0'
+  | 'A1'
+  | 'A2'
+  | 'A3'
+  | 'A4'
+  | 'A5';
+```
+
+---
+
+### margins
+
+Type:
+
+```ts
+{
+  top: PageMargin;
+  right: PageMargin;
+  bottom: PageMargin;
+  left: PageMargin;
+}
+```
+
+Default:
+
+```ts
+{
+  top: '0.4in',
+  right: '0.4in',
+  bottom: '0.4in',
+  left: '0.4in'
+}
+```
+
+Controls the page margins on all four sides. Values can be provided in inches (`in`), centimeters (`cm`), millimeters (`mm`), or points (`pt`).
+
+Supported values:
+
+```ts
+type PageMargin =
+  // Inches
+  | '0in'
+  | '0.25in'
+  | '0.4in'
+  | '0.5in'
+  | '0.75in'
+  | '1in'
+  | '1.25in'
+  | '1.5in'
+  | '1.75in'
+  | '2in'
+  // Centimeters
+  | '0cm'
+  | '0.5cm'
+  | '1cm'
+  | '1.5cm'
+  | '2cm'
+  | '2.5cm'
+  | '3cm'
+  | '4cm'
+  | '5cm'
+  // Millimeters
+  | '0mm'
+  | '5mm'
+  | '10mm'
+  | '15mm'
+  | '20mm'
+  | '25mm'
+  | '30mm'
+  | '40mm'
+  | '50mm'
+  // Points
+  | '0pt'
+  | '18pt'
+  | '36pt'
+  | '54pt'
+  | '72pt'
+  | '90pt'
+  | '108pt'
+  | '144pt';
+```
+
+Example usage:
+
+```ts
+import { ExportPdf } from 'reactjs-tiptap-editor/exportpdf';
+
+ExportPdf.configure({
+  paperSize: 'Letter',
+  margins: {
+    top: '1in',
+    right: '1in',
+    bottom: '1in',
+    left: '1in',
+  },
+});
+```

--- a/src/extensions/ExportPdf/ExportPdf.ts
+++ b/src/extensions/ExportPdf/ExportPdf.ts
@@ -3,16 +3,35 @@ import { Extension } from '@tiptap/core';
 import { ActionButton } from '@/components';
 import { printEditorContent } from '@/utils/pdf';
 
-export const ExportPdf = /* @__PURE__ */ Extension.create<any>({
+import type { GeneralOptions, PaperSize, PageMargin } from '@/types';
+
+export interface ExportPdfOptions extends GeneralOptions<ExportPdfOptions> {
+  paperSize: PaperSize;
+  margins: {
+    top?: PageMargin;
+    right?: PageMargin;
+    bottom?: PageMargin;
+    left?: PageMargin;
+  };
+}
+
+export const ExportPdf = /* @__PURE__ */ Extension.create<ExportPdfOptions>({
   name: 'exportPdf',
   addOptions() {
     return {
       ...this.parent?.(),
-      button: ({ editor, t }: any) => ({
+      paperSize: 'Letter',
+      margins: {
+        top: '0.4in',
+        right: '0.4in',
+        bottom: '0.4in',
+        left: '0.4in',
+      },
+      button: ({ editor, extension, t }) => ({
         component: ActionButton,
         componentProps: {
           action: () => {
-            printEditorContent(editor);
+            printEditorContent(editor, extension.options);
           },
           icon: 'ExportPdf',
           tooltip: t('editor.exportPdf.tooltip'),

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,3 +264,47 @@ export interface NameValueOption<T = string> {
 }
 
 export type VideoAlignment = 'flex-start' | 'center' | 'flex-end';
+
+export type PaperSize = 'Legal' | 'Letter' | 'Tabloid' | 'A0' | 'A1' | 'A2' | 'A3' | 'A4' | 'A5';
+
+export type PageMargin =
+  // Inches (in)
+  '0in'
+  | '0.25in'
+  | '0.4in'
+  | '0.5in'
+  | '0.75in'
+  | '1in'
+  | '1.25in'
+  | '1.5in'
+  | '1.75in'
+  | '2in'
+  // Centimeters (cm)
+  | '0cm'
+  | '0.5cm'
+  | '1cm'
+  | '1.5cm'
+  | '2cm'
+  | '2.5cm'
+  | '3cm'
+  | '4cm'
+  | '5cm'
+  // Millimeters (mm)
+  | '0mm'
+  | '5mm'
+  | '10mm'
+  | '15mm'
+  | '20mm'
+  | '25mm'
+  | '30mm'
+  | '40mm'
+  | '50mm'
+  // Points (pt)
+  | '0pt'
+  | '18pt'
+  | '36pt'
+  | '54pt'
+  | '72pt'
+  | '90pt'
+  | '108pt'
+  | '144pt';

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -2,68 +2,43 @@ import type { Editor } from '@tiptap/core';
 
 function printHtml(content: string) {
   const iframe: HTMLIFrameElement = document.createElement('iframe');
-  iframe.setAttribute('style', 'position: absolute; width: 0; height: 0; top: 0; left: 0;');
+  iframe.setAttribute(
+    'style',
+    'position: absolute; width: 0; height: 0; top: 0; left: 0;'
+  );
   document.body.appendChild(iframe);
 
-  iframe.textContent = `
-    <!DOCTYPE html>
-    <html lang="en">
-    <head>
-      <title>Echo Editor</title>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    </head>
-    <body class="is-print">
-      <div class="tiptap ProseMirror" translate="no" aria-expanded="false">
-          ${content}
-      </div>
-    </body>
-    </html>
-  `;
+  const doc = iframe.contentDocument || iframe.contentWindow?.document;
 
-  const frameWindow = iframe.contentWindow;
-  const doc: any = iframe.contentDocument || (iframe.contentWindow && iframe.contentWindow.document);
+  if (!doc) return;
 
-  // load style from CDN to iframe
+  doc.open();
+  doc.write(content);
+  doc.close();
+
   const link = document.createElement('link');
   link.rel = 'stylesheet';
-  link.href = 'https://cdn.jsdelivr.net/npm/reactjs-tiptap-editor@latest/lib/style.css';
+  link.href =
+    'https://cdn.jsdelivr.net/npm/reactjs-tiptap-editor@latest/lib/style.css';
   doc.head.appendChild(link);
 
-  if (doc) {
-    doc.open();
-    doc.write(content);
-    doc.close();
-  }
-
-  if (frameWindow) {
-    iframe.addEventListener('load', function () {
+  iframe.addEventListener('load', function () {
+    setTimeout(() => {
       try {
-        setTimeout(() => {
-          frameWindow.focus();
-          try {
-            if (!frameWindow.document.execCommand('print', false)) {
-              frameWindow.print();
-            }
-          } catch {
-            frameWindow.print();
-          }
-          frameWindow.close();
-        }, 10);
+        iframe.contentWindow?.focus();
+        iframe.contentWindow?.print();
       } catch (err) {
         console.error(err);
       }
-
       setTimeout(() => {
         document.body.removeChild(iframe);
       }, 100);
-    });
-  }
+    }, 50);
+  });
 }
 
 export function printEditorContent(editor: Editor) {
   const content = editor.getHTML();
-
   if (content) {
     printHtml(content);
     return true;

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -1,6 +1,7 @@
 import type { Editor } from '@tiptap/core';
+import { ExportPdfOptions } from '@/extensions/ExportPdf';
 
-function printHtml(content: string) {
+function printHtml(content: string, exportPdfOptions: ExportPdfOptions) {
   const iframe: HTMLIFrameElement = document.createElement('iframe');
   iframe.setAttribute(
     'style',
@@ -9,7 +10,18 @@ function printHtml(content: string) {
   document.body.appendChild(iframe);
 
   const doc = iframe.contentDocument || iframe.contentWindow?.document;
+
   if (!doc) return;
+
+  const {
+    paperSize,
+    margins: {
+      top: marginTop,
+      right: marginRight,
+      bottom: marginBottom,
+      left: marginLeft,
+    },
+  } = exportPdfOptions;
 
   const html = `
     <!DOCTYPE html>
@@ -21,8 +33,8 @@ function printHtml(content: string) {
       <style>
         @media print {
           @page {
-            size: Letter;
-            margin: 0.4in 0.4in 0.4in 0.4in;
+            size: ${paperSize};
+            margin: ${marginTop} ${marginRight} ${marginBottom} ${marginLeft}; /* top, right, bottom, left */
           }
 
           body {
@@ -55,7 +67,7 @@ function printHtml(content: string) {
   doc.write(html);
   doc.close();
 
-  iframe.onload = () => {
+  iframe.addEventListener('load', () => {
     setTimeout(() => {
       try {
         iframe.contentWindow?.focus();
@@ -67,13 +79,16 @@ function printHtml(content: string) {
         document.body.removeChild(iframe);
       }, 100);
     }, 50);
-  };
+  });
 }
 
-export function printEditorContent(editor: Editor) {
+export function printEditorContent(
+  editor: Editor,
+  exportPdfOptions: ExportPdfOptions
+) {
   const content = editor.getHTML();
   if (content) {
-    printHtml(content);
+    printHtml(content, exportPdfOptions);
     return true;
   }
   return false;

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -9,32 +9,65 @@ function printHtml(content: string) {
   document.body.appendChild(iframe);
 
   const doc = iframe.contentDocument || iframe.contentWindow?.document;
-
   if (!doc) return;
 
+  const html = `
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <title>Echo Editor</title>
+      <meta charset="UTF-8">
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <style>
+        @media print {
+          @page {
+            size: Letter;
+            margin: 0.4in 0.4in 0.4in 0.4in;
+          }
+
+          body {
+            background: none;
+            margin: 0;
+            padding: 0;
+          }
+
+          .print-container {
+            width: 100%;
+            box-sizing: border-box;
+          }
+
+          .no-print {
+            display: none;
+          }
+        }
+      </style>
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reactjs-tiptap-editor@latest/lib/style.css">
+    </head>
+    <body>
+      <div class="print-container">
+        ${content}
+      </div>
+    </body>
+    </html>
+  `;
+
   doc.open();
-  doc.write(content);
+  doc.write(html);
   doc.close();
 
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href =
-    'https://cdn.jsdelivr.net/npm/reactjs-tiptap-editor@latest/lib/style.css';
-  doc.head.appendChild(link);
-
-  iframe.addEventListener('load', function () {
+  iframe.onload = () => {
     setTimeout(() => {
       try {
         iframe.contentWindow?.focus();
         iframe.contentWindow?.print();
       } catch (err) {
-        console.error(err);
+        console.error('Print failed', err);
       }
       setTimeout(() => {
         document.body.removeChild(iframe);
       }, 100);
     }, 50);
-  });
+  };
 }
 
 export function printEditorContent(editor: Editor) {


### PR DESCRIPTION
### Summary

This PR introduces customization options for the `exportPdf` extension in **reactjs-tiptap-editor**, allowing users to configure the exported PDF’s paper size and margins.

---

### What's New

* Added `ExportPdfOptions` interface to define:
  * `paperSize` (`A4`, `Letter`, `Legal`, etc.)
  * `margins` (top, right, bottom, left in `cm`, `mm`, `in`, or `pt`)
* Integrated the options into `printEditorContent` and `printHtml` logic
* Defined sensible defaults for paper size and margins
* Updated relevant docs to reflect the new configuration options

---

### Motivation

The project I’m working on required fine-grained control over the PDF export layout (especially margins and paper size). The current implementation lacked customization hooks, so this PR addresses that by making export options configurable.

---

### Testing

Tested locally with various configurations for paper size and margins — all behave as expected during PDF export.

---

Let me know if any changes are required or if you'd prefer these options implemented differently!
