### PR TITLE
fix(image): enable text wrapping for inline images aligned left or right

### DIFF
--- a/src/extensions/Image/Image.ts
+++ b/src/extensions/Image/Image.ts
@@ -174,11 +174,19 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
   },
   renderHTML({ HTMLAttributes }) {
     const { flipX, flipY, align, inline } = HTMLAttributes;
+    const inlineFloat = inline && (align === 'left' || align === 'right');
 
     const transformStyle
       = flipX || flipY ? `transform: rotateX(${flipX ? '180' : '0'}deg) rotateY(${flipY ? '180' : '0'}deg);` : '';
 
-    const textAlignStyle = align ? `text-align: ${align};` : '';
+    const textAlignStyle = inlineFloat ? '' : `text-align: ${align};`;
+
+    const floatStyle = inlineFloat ? `float: ${align};` : '';
+
+    const marginStyle 
+      = inlineFloat ? (align === 'left' ? 'margin: 1em 1em 1em 0;' : 'margin: 1em 0 1em 1em;') : '';
+
+    const style = `${floatStyle}${marginStyle}${transformStyle}`;
 
     return [
       inline ? 'span' : 'div',
@@ -191,7 +199,7 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
         mergeAttributes(
           {
             height: 'auto',
-            style: transformStyle,
+            style,
           },
           this.options.HTMLAttributes,
           HTMLAttributes,

--- a/src/extensions/Image/components/ImageView.tsx
+++ b/src/extensions/Image/components/ImageView.tsx
@@ -48,6 +48,7 @@ function ImageView(props: any) {
   });
 
   const { align, inline } = props?.node?.attrs;
+  const inlineFloat = inline && (align === 'left' || align === 'right');
 
   const imgAttrs = useMemo(() => {
     const { src, alt, width: w, height: h, flipX, flipY } = props?.node?.attrs;
@@ -62,6 +63,8 @@ function ImageView(props: any) {
       transformStyles.push('rotateY(180deg)');
     const transform = transformStyles.join(' ');
 
+    const floatStyle = inlineFloat ? { float: align }: {};
+
     return {
       src: src || undefined,
       alt: alt || undefined,
@@ -69,6 +72,7 @@ function ImageView(props: any) {
         width: width || undefined,
         height: height || undefined,
         transform: transform || 'none',
+        ...floatStyle,
       },
     };
   }, [props?.node?.attrs]);
@@ -229,7 +233,14 @@ function ImageView(props: any) {
     <NodeViewWrapper
       as={inline ? 'span' : 'div'}
       className="image-view"
-      style={{ ...imageMaxStyle, textAlign: align, display: inline ? 'inline' : 'block' }}
+      style={{
+        float: inlineFloat ? align : undefined,
+        margin: inlineFloat ? align === 'left' ? '1em 1em 1em 0' : '1em 0 1em 1em' : undefined,
+        display: inline ? 'inline' : 'block',
+        textAlign: inlineFloat ? undefined : align,
+        width: imgAttrs.style?.width ?? 'auto',
+        ...(inlineFloat ? {} : imageMaxStyle),
+      }}
     >
       <div
         data-drag-handle


### PR DESCRIPTION
### Summary

This PR fixes text wrapping for images when they are inline and aligned either to the left or to the right.

---

### Testing

#### how the issue looks inside the editor
<img width="1091" height="478" alt="before" src="https://github.com/user-attachments/assets/74a6ef23-9959-4ce5-a2fa-17e65436be9c" />

#### how the issue looks inside the exported PDF
<img width="447" height="376" alt="exported-before" src="https://github.com/user-attachments/assets/519e1b68-b5d2-40e8-ada8-7c5d8d54bff6" />

#### how the fix looks inside the editor
<img width="931" height="446" alt="after" src="https://github.com/user-attachments/assets/8b53dd32-6028-4595-a195-0515ebfd94eb" />

#### how the fix looks inside the exported PDF
<img width="453" height="410" alt="exported-after" src="https://github.com/user-attachments/assets/2a62f8c0-6a46-4663-b58a-c0ed499df177" />

---

### Future Improvements
- fix the issue where text doesn’t wrap correctly around inline images that are center-aligned (in both the editor and the exported PDF).
- fix how block images look in the exported PDF when they are aligned to the left or right.

---

Let me know if any changes are required.
