### PR TITLE
fix(image): improve crop modal and upload handling

### DIFF
--- a/src/components/icons/icons.ts
+++ b/src/components/icons/icons.ts
@@ -76,7 +76,8 @@ import {
   ZoomIn,
   ZoomOut,
   PencilRuler,
-  WrapText
+  WrapText,
+  Loader2 as Loader,
 } from 'lucide-react';
 
 import {
@@ -91,6 +92,7 @@ import {
   SizeM,
   SizeS,
 } from '@/components/icons';
+import { CodeView } from '@/components/icons/CodeView';
 import { ColumnAddLeft } from '@/components/icons/ColumnAddLeft';
 import { ColumnAddRight } from '@/components/icons/ColumnAddRight';
 import { Direction } from '@/components/icons/Direction';
@@ -102,7 +104,6 @@ import { LeftToRight } from '@/components/icons/LeftToRight';
 import { Mermaid } from '@/components/icons/Mermaid';
 import { RightToLeft } from '@/components/icons/RightToLeft';
 import { Twitter } from '@/components/icons/Twitter';
-import { CodeView } from '@/components/icons/CodeView';
 
 import ImportWord from './ImportWord';
 
@@ -212,5 +213,6 @@ export const icons = {
   FlipX: FlipVertical,
   FlipY: FlipHorizontal,
   PencilRuler,
-  WrapText
+  WrapText,
+  Loader,
 } as any;

--- a/src/extensions/Image/Image.ts
+++ b/src/extensions/Image/Image.ts
@@ -30,6 +30,7 @@ export interface SetImageAttrsOptions {
 const DEFAULT_OPTIONS: any = {
   acceptMimes: ['image/jpeg', 'image/gif', 'image/png', 'image/jpg'],
   maxSize: 1024 * 1024 * 5, // 5MB
+  multiple: true,
   resourceImage: 'both',
   defaultInline: false,
 };
@@ -59,12 +60,20 @@ export interface IImageOptions extends GeneralOptions<IImageOptions> {
 
   HTMLAttributes?: any
 
+  multiple?: boolean
   acceptMimes?: string[]
   maxSize?: number
 
   /** The source URL of the image */
   resourceImage: 'upload' | 'link' | 'both'
-  defaultInline?: boolean
+  defaultInline?: boolean,
+
+  /** Function to handle errors during file validation */
+  onError?: (error: {
+    type: 'size' | 'type' | 'upload';
+    message: string;
+    file?: File;
+  }) => void;
 }
 
 export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -116,6 +116,7 @@ const locale = {
   'editor.fullscreen.tooltip.exit': 'Fullscreen Exit',
   'editor.imageUpload.cancel': 'Cancel',
   'editor.imageUpload.crop': 'Crop',
+  'editor.imageUpload.uploading': 'Uploading...',
   'editor.imageUpload.fileTypeNotSupported': 'File type not supported',
   'editor.imageUpload.fileSizeTooBig': 'File size too big, Maximum size is',
   'editor.table.menu.insertColumnBefore': 'Insert Column Before',
@@ -169,6 +170,9 @@ const locale = {
   'editor.codeView.tooltip': 'Code View',
   'editor.tooltip.flipX': 'Flip Horizontal',
   'editor.tooltip.flipY': 'Flip Vertical',
+  'editor.upload.fileTypeNotSupported': '{fileName} file type not supported',
+  'editor.upload.fileSizeTooBig': '{fileName} file size too big, maximum size is {size}MB',
+  'editor.upload.error': 'Error uploading file',
 };
 
 export default locale;

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -116,6 +116,7 @@ const locale = {
   'editor.fullscreen.tooltip.exit': 'Kilépés teljes képernyős módból',
   'editor.imageUpload.cancel': 'Mégsem',
   'editor.imageUpload.crop': 'Körbevágás',
+  'editor.imageUpload.uploading': 'Feltöltés...',
   'editor.imageUpload.fileTypeNotSupported': 'Fájltípus nem támogatott',
   'editor.imageUpload.fileSizeTooBig': 'A fájlméret túl nagy, a maximum méret',
   'editor.table.menu.insertColumnBefore': 'Oszlop beszúrása balra',
@@ -169,6 +170,9 @@ const locale = {
   'editor.codeView.tooltip': 'Kódnézet',
   'editor.tooltip.flipX': 'Vízszintes tükrözés',
   'editor.tooltip.flipY': 'Függőleges tükrözés',
+  'editor.upload.fileTypeNotSupported': '{fileName} fájltípus nem támogatott',
+  'editor.upload.fileSizeTooBig': '{fileName} fájlméret túl nagy, maximális méret {size}MB',
+  'editor.upload.error': 'Hiba a fájl feltöltésekor',
 };
 
 export default locale;

--- a/src/locales/pt-br.ts
+++ b/src/locales/pt-br.ts
@@ -116,6 +116,7 @@ const locale = {
   'editor.fullscreen.tooltip.exit': 'Sair da tela cheia',
   'editor.imageUpload.cancel': 'Cancelar',
   'editor.imageUpload.crop': 'Cortar',
+  'editor.imageUpload.uploading': 'Enviando...',
   'editor.imageUpload.fileTypeNotSupported': 'Tipo de arquivo não suportado',
   'editor.imageUpload.fileSizeTooBig': 'Tamanho do arquivo muito grande, tamanho máximo é',
   'editor.table.menu.insertColumnBefore': 'Inserir coluna antes',
@@ -169,6 +170,9 @@ const locale = {
   'editor.codeView.tooltip': 'Visualização de código',
   'editor.tooltip.flipX': 'Inverter Horizontal',
   'editor.tooltip.flipY': 'Inverter Vertical',
+  'editor.upload.fileTypeNotSupported': '{fileName} tipo de arquivo não suportado',
+  'editor.upload.fileSizeTooBig': '{fileName} tamanho do arquivo muito grande, o tamanho máximo é {size}MB',
+  'editor.upload.error': 'Erro ao enviar arquivo',
 };
 
 export default locale;

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -116,6 +116,7 @@ const locale = {
   'editor.fullscreen.tooltip.exit': 'Thoát toàn màn hình',
   'editor.imageUpload.cancel': 'Hủy',
   'editor.imageUpload.crop': 'Cắt',
+  'editor.imageUpload.uploading': 'Đang tải lên...',
   'editor.imageUpload.fileTypeNotSupported': 'Loại tệp không được hỗ trợ',
   'editor.imageUpload.fileSizeTooBig': 'Kích thước tệp quá lớn, Kích thước tối đa là',
   'editor.table.menu.insertColumnBefore': 'Chèn cột trước',
@@ -169,6 +170,9 @@ const locale = {
   'editor.codeView.tooltip': 'Xem mã',
   'editor.tooltip.flipX': 'Lật Ngang',
   'editor.tooltip.flipY': 'Lật Dọc',
+  'editor.upload.fileTypeNotSupported': '{fileName} loại tệp không được hỗ trợ',
+  'editor.upload.fileSizeTooBig': '{fileName} kích thước tệp quá lớn, kích thước tối đa là {size}MB',
+  'editor.upload.error': 'Lỗi khi tải lên tệp',
 };
 
 export default locale;

--- a/src/locales/zh-cn.ts
+++ b/src/locales/zh-cn.ts
@@ -116,6 +116,7 @@ const locale = {
   'editor.fullscreen.tooltip.exit': '退出全屏',
   'editor.imageUpload.cancel': '取消',
   'editor.imageUpload.crop': '裁剪',
+  'editor.imageUpload.uploading': '上传中...',
   'editor.imageUpload.fileTypeNotSupported': '不支持的文件类型',
   'editor.imageUpload.fileSizeTooBig': '文件大小超出限制，最大大小为',
   'editor.table.menu.insertColumnBefore': '在前面插入列',
@@ -169,6 +170,9 @@ const locale = {
   'editor.codeView.tooltip': '代码视图',
   'editor.tooltip.flipX': '水平翻转',
   'editor.tooltip.flipY': '垂直翻转',
+  'editor.upload.fileTypeNotSupported': '{fileName} 文件类型不受支持',
+  'editor.upload.fileSizeTooBig': '{fileName} 文件大小超出限制，最大大小为 {size}MB',
+  'editor.upload.error': '上传文件时出错',
 };
 
 export default locale;

--- a/src/utils/validateFile.ts
+++ b/src/utils/validateFile.ts
@@ -1,0 +1,73 @@
+import type {
+  ToastProps,
+} from '@/components/ui/toast';
+import { type TranslationFunction } from '@/locales';
+
+interface ValidateFileOptions {
+  acceptMimes: string[];
+  maxSize: number;
+  t: TranslationFunction;
+  toast: (props: ToastProps) => void;
+  onError?: (error: {
+    type: 'size' | 'type' | 'upload';
+    message: string;
+    file?: File;
+  }) => void;
+}
+
+export function validateFiles(
+  files: File[] | { [key: string]: File },
+  options: ValidateFileOptions
+): File[] {
+  const { acceptMimes, maxSize, t, toast } = options;
+  const validFiles: File[] = [];
+
+  const filesArray = Array.isArray(files)
+    ? files
+    : Object.values(files);
+
+  filesArray.forEach((file) => {
+    let isValid = true;
+
+    // Validate file type
+    if (!acceptMimes.includes(file.type)) {
+      if (options.onError) {
+        options.onError({
+          type: 'type',
+          message: t('editor.upload.fileTypeNotSupported', { fileName: file.name }),
+          file,
+        });
+      } else {
+        toast({
+          variant: 'default',
+          title: t('editor.upload.fileTypeNotSupported', { fileName: file.name }),
+        });
+      }
+      isValid = false;
+    }
+
+    // Validate file size
+    if (file.size > maxSize) {
+      const maxSizeInMB = (maxSize / 1024 / 1024).toFixed(2);
+      if (options.onError) {
+        options.onError({
+          type: 'size',
+          message: t('editor.upload.fileSizeTooBig', { fileName: file.name, size: maxSizeInMB }),
+          file,
+        });
+      } else {
+        toast({
+          variant: 'default',
+          title: t('editor.upload.fileSizeTooBig', { fileName: file.name, size: maxSizeInMB }),
+        });
+      }
+      isValid = false;
+    }
+
+    if (isValid) {
+      validFiles.push(file);
+    }
+  });
+
+  return validFiles;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -89,6 +89,7 @@ export default {
         'accordion-up': 'accordion-up 0.2s ease-out',
         'collapsible-down': 'collapsible-down 0.2s ease-in-out',
         'collapsible-up': 'collapsible-up 0.2s ease-in-out',
+        spin: 'spin 1s linear infinite',
       },
     },
   },


### PR DESCRIPTION
- Fix close button not working in crop image modal
- Add loading state after cropping to prevent duplicate uploads
- Clear file info when canceling crop to fix same file re-selection issue
- Add loading indicator for normal image upload
- Fix 'multiple', 'acceptMimes', and 'maxSize' props not working properly
- Add 'onError' callback for upload failure handling
- Support i18n variable interpolation