### PR TITLE
fix(image): imageInline only applied on the first image insertion

### DIFF
--- a/docs/extensions/ExportPdf/index.md
+++ b/docs/extensions/ExportPdf/index.md
@@ -22,8 +22,6 @@ const extensions = [
 ];
 ```
 
-Here’s the documentation in the same style:
-
 ---
 
 ## Options
@@ -31,6 +29,7 @@ Here’s the documentation in the same style:
 ### paperSize
 
 Type: `PaperSize`
+
 Default: `'Letter'`
 
 Specifies the size of the paper used when exporting to PDF.
@@ -49,8 +48,6 @@ type PaperSize =
   | 'A4'
   | 'A5';
 ```
-
----
 
 ### margins
 
@@ -130,12 +127,12 @@ Example usage:
 import { ExportPdf } from 'reactjs-tiptap-editor/exportpdf';
 
 ExportPdf.configure({
-  paperSize: 'Letter',
+  paperSize: 'A4',
   margins: {
     top: '1in',
-    right: '1in',
+    right: '0.4in',
     bottom: '1in',
-    left: '1in',
+    left: '0.4in',
   },
 });
 ```

--- a/src/extensions/Image/components/ActionImageButton.tsx
+++ b/src/extensions/Image/components/ActionImageButton.tsx
@@ -20,9 +20,10 @@ function ActionImageButton(props: any) {
   const [link, setLink] = useState<string>('');
   const fileInput = useRef<HTMLInputElement>(null);
 
-  const [imageInline, setImageInline] = useState(props.editor.extensionManager.extensions.find(
+  const defaultInline = props.editor.extensionManager.extensions.find(
     (extension: any) => extension.name === Image.name,
-  )?.options.defaultInline || false);
+  )?.options.defaultInline || false;
+  const [imageInline, setImageInline] = useState(defaultInline);
 
   const uploadOptions = useMemo(() => {
     const uploadOptions = props.editor.extensionManager.extensions.find(
@@ -57,7 +58,7 @@ function ActionImageButton(props: any) {
 
     props.editor.chain().focus().setImageInline({ src, inline: imageInline }).run();
     setOpen(false);
-    setImageInline(false);
+    setImageInline(defaultInline);
   }
   function handleLink(e: any) {
     e.preventDefault();
@@ -65,7 +66,7 @@ function ActionImageButton(props: any) {
 
     props.editor.chain().focus().setImageInline({ src: link, inline: imageInline }).run();
     setOpen(false);
-    setImageInline(false);
+    setImageInline(defaultInline);
     setLink('');
   }
 


### PR DESCRIPTION
### Summary
Passing `defaultInline` option to image extension only works when inserting an image for the first time. This PR fixes the issue by resetting `imageInline` to `defaultInline` after image insertion. It also includes some minor fixes for export pdf documentation.

