### PR TITLE
feat(image): add alt text support with i18n and configurable editing

### DIFF
--- a/docs/extensions/Image/index.md
+++ b/docs/extensions/Image/index.md
@@ -53,6 +53,8 @@ interface IImageOptions extends GeneralOptions<IImageOptions> {
   resourceImage: 'upload' | 'link' | 'both'
   defaultInline?: boolean,
 
+  enableAlt?: boolean,
+
   onError?: (error: {
     type: 'size' | 'type' | 'upload';
     message: string;
@@ -70,6 +72,7 @@ interface IImageOptions extends GeneralOptions<IImageOptions> {
 | `maxSize`        | `number`                                                                                | Maximum size limit for a single image (in bytes), triggers `onError` when exceeded.                                  | No       | `5MB`   |
 | `resourceImage`  | `'upload' \| 'link' \| 'both'`                                                          | Image source method: - `'upload'`: Upload only - `'link'`: Link only - `'both'`: Both supported                     | Yes      | `both`  |
 | `defaultInline`  | `boolean`                                                                               | Whether to insert images as inline elements by default.                                                               | No       | `false` |
+| `enableAlt`      | `boolean`                                                                               | Whether to enable alt text editing for images.                                                               | No       | `true` |
 | `onError`        | `(error: { type: 'size' \| 'type' \| 'upload'; message: string; file?: File }) => void` | Callback function for upload or validation failures. Contains error type (size, type, upload), error message, and corresponding file. | No       | None    |
 
 ### resourceImage Type Description

--- a/src/extensions/Image/Image.ts
+++ b/src/extensions/Image/Image.ts
@@ -33,6 +33,7 @@ const DEFAULT_OPTIONS: any = {
   multiple: true,
   resourceImage: 'both',
   defaultInline: false,
+  enableAlt: true,
 };
 
 declare module '@tiptap/core' {
@@ -67,6 +68,9 @@ export interface IImageOptions extends GeneralOptions<IImageOptions> {
   /** The source URL of the image */
   resourceImage: 'upload' | 'link' | 'both'
   defaultInline?: boolean,
+
+  // Enable alternative text input
+  enableAlt?: boolean
 
   /** Function to handle errors during file validation */
   onError?: (error: {

--- a/src/extensions/Image/components/ActionImageButton.tsx
+++ b/src/extensions/Image/components/ActionImageButton.tsx
@@ -98,6 +98,7 @@ function ActionImageButton(props: any) {
       }
 
       setOpen(false);
+      setAlt('');
       setImageInline(defaultInline);
     } catch (error) {
       console.error('Error uploading image', error);
@@ -126,6 +127,7 @@ function ActionImageButton(props: any) {
     setOpen(false);
     setImageInline(defaultInline);
     setLink('');
+    setAlt('');
   }
 
   function handleClick(e: any) {
@@ -225,10 +227,14 @@ function ActionImageButton(props: any) {
               </Button>
 
               <ImageCropper
+                alt={alt}
                 disabled={isUploading}
                 editor={props.editor}
                 imageInline={imageInline}
-                onClose={() => actionDialogImage.setOpen(props.editor.id, false)}
+                onClose={() => {
+                  actionDialogImage.setOpen(props.editor.id, false);
+                  setAlt('');
+                }}
               />
             </div>
 

--- a/src/extensions/Image/components/ActionImageButton.tsx
+++ b/src/extensions/Image/components/ActionImageButton.tsx
@@ -192,18 +192,22 @@ function ActionImageButton(props: any) {
             </Label>
           </div>
 
-          <div className="richtext-my-[10px] ">
-            <Label className="mb-[6px]">
-              {t('editor.imageUpload.alt')}
-            </Label>
+          {
+            uploadOptions.enableAlt && (
+              <div className="richtext-my-[10px] ">
+                <Label className="mb-[6px]">
+                  {t('editor.imageUpload.alt')}
+                </Label>
 
-            <Input
-              onChange={(e) => setAlt(e.target.value)}
-              required
-              type="text"
-              value={alt}
-            />
-          </div>
+                <Input
+                  onChange={(e) => setAlt(e.target.value)}
+                  required
+                  type="text"
+                  value={alt}
+                />
+              </div>
+            )
+          }
 
           <TabsContent value="upload">
             <div className="richtext-flex richtext-items-center richtext-gap-[10px]">

--- a/src/extensions/Image/components/ActionImageButton.tsx
+++ b/src/extensions/Image/components/ActionImageButton.tsx
@@ -194,7 +194,7 @@ function ActionImageButton(props: any) {
 
           <div className="richtext-my-[10px] ">
             <Label className="mb-[6px]">
-              Alt
+              {t('editor.imageUpload.alt')}
             </Label>
 
             <Input

--- a/src/extensions/Image/components/ImageCropper.tsx
+++ b/src/extensions/Image/components/ImageCropper.tsx
@@ -19,7 +19,7 @@ import { useLocale } from '@/locales';
 import { dataURLtoFile, readImageAsBase64 } from '@/utils/file';
 import { validateFiles } from '@/utils/validateFile';
 
-export function ImageCropper({ editor, imageInline, onClose, disabled }: any) {
+export function ImageCropper({ editor, imageInline, onClose, disabled, alt }: any) {
   const { t } = useLocale();
   const { toast } = useToast();
 
@@ -92,7 +92,7 @@ export function ImageCropper({ editor, imageInline, onClose, disabled }: any) {
         src = URL.createObjectURL(fileCrop);
       }
 
-      editor.chain().focus().setImageInline({ src, inline: imageInline }).run();
+      editor.chain().focus().setImageInline({ src, inline: imageInline, alt }).run();
 
       setDialogOpen(false);
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -117,6 +117,7 @@ const locale = {
   'editor.imageUpload.cancel': 'Cancel',
   'editor.imageUpload.crop': 'Crop',
   'editor.imageUpload.uploading': 'Uploading...',
+  'editor.imageUpload.alt': 'Alt Text',
   'editor.imageUpload.fileTypeNotSupported': 'File type not supported',
   'editor.imageUpload.fileSizeTooBig': 'File size too big, Maximum size is',
   'editor.table.menu.insertColumnBefore': 'Insert Column Before',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -117,6 +117,7 @@ const locale = {
   'editor.imageUpload.cancel': 'Mégsem',
   'editor.imageUpload.crop': 'Körbevágás',
   'editor.imageUpload.uploading': 'Feltöltés...',
+  'editor.imageUpload.alt': 'Alternatív szöveg',
   'editor.imageUpload.fileTypeNotSupported': 'Fájltípus nem támogatott',
   'editor.imageUpload.fileSizeTooBig': 'A fájlméret túl nagy, a maximum méret',
   'editor.table.menu.insertColumnBefore': 'Oszlop beszúrása balra',

--- a/src/locales/pt-br.ts
+++ b/src/locales/pt-br.ts
@@ -117,6 +117,7 @@ const locale = {
   'editor.imageUpload.cancel': 'Cancelar',
   'editor.imageUpload.crop': 'Cortar',
   'editor.imageUpload.uploading': 'Enviando...',
+  'editor.imageUpload.alt': 'Texto alternativo',
   'editor.imageUpload.fileTypeNotSupported': 'Tipo de arquivo não suportado',
   'editor.imageUpload.fileSizeTooBig': 'Tamanho do arquivo muito grande, tamanho máximo é',
   'editor.table.menu.insertColumnBefore': 'Inserir coluna antes',

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -117,6 +117,7 @@ const locale = {
   'editor.imageUpload.cancel': 'Hủy',
   'editor.imageUpload.crop': 'Cắt',
   'editor.imageUpload.uploading': 'Đang tải lên...',
+  'editor.imageUpload.alt': 'Văn bản thay thế',
   'editor.imageUpload.fileTypeNotSupported': 'Loại tệp không được hỗ trợ',
   'editor.imageUpload.fileSizeTooBig': 'Kích thước tệp quá lớn, Kích thước tối đa là',
   'editor.table.menu.insertColumnBefore': 'Chèn cột trước',

--- a/src/locales/zh-cn.ts
+++ b/src/locales/zh-cn.ts
@@ -117,6 +117,7 @@ const locale = {
   'editor.imageUpload.cancel': '取消',
   'editor.imageUpload.crop': '裁剪',
   'editor.imageUpload.uploading': '上传中...',
+  'editor.imageUpload.alt': '替代文本',
   'editor.imageUpload.fileTypeNotSupported': '不支持的文件类型',
   'editor.imageUpload.fileSizeTooBig': '文件大小超出限制，最大大小为',
   'editor.table.menu.insertColumnBefore': '在前面插入列',


### PR DESCRIPTION
- add alt attribute for cropped images and reset alt content after successful upload or link insertion
- add i18n support for image alt text
- add enableAlt prop to control alt text editing

To ensure that existing user functionality is not affected, enableAlt is currently set to true by default. However, since most rich text editor users are unlikely to use this feature, it may be better to disable it by default and let those who need it enable it explicitly via the documentation.



