### PR TITLE
fix: fix not fill the text when make a normal text to a link

### DIFF
--- a/src/extensions/Link/components/LinkEditBlock.tsx
+++ b/src/extensions/Link/components/LinkEditBlock.tsx
@@ -32,6 +32,9 @@ function LinkEditBlock(props: IPropsLinkEditBlock) {
         const LinkOptions = props.editor.extensionManager.extensions.find(
           (ext: any) => ext.name === Link.name,
         )?.options;
+        const { from, to } = props.editor.state.selection;
+        const text = props.editor.state.doc.textBetween(from, to, " ");
+        setForm({ link: "", text });
         setOpenInNewTab(LinkOptions?.HTMLAttributes?.target === '_blank');
       }
     };


### PR DESCRIPTION
Fig bug #299 
You need check PR more carefully, i dont think I had this bug before I update the latest version