### PR TITLE
fix(bubble): remove duplicate underline button

### DIFF
--- a/src/components/Bubble/RichTextBubbleText.tsx
+++ b/src/components/Bubble/RichTextBubbleText.tsx
@@ -36,7 +36,6 @@ function DefaultButtonBubble () {
     <RichTextBold />
     <RichTextItalic />
     <RichTextUnderline />
-    <RichTextUnderline />
     <RichTextStrike />
     <RichTextCode/>
     <RichTextLink />


### PR DESCRIPTION
Fix for duplicated U (underline text) menu item in bubble menu

How to repro initial behavior:
1. Open playground
2. Type some text (e.g. "Hello")
3. Select it
==> In the bubble menu you will see duplicated item "U"

Fixed behavior: Only one "U" item is present in the bubble menu
<img width="508" height="368" alt="bubble-menu-duplicated-item" src="https://github.com/user-attachments/assets/4f7a9806-2eb9-4fb3-bff2-ae5f71f3fc63" />