### PR TITLE
fix(playground): removed duplicated heading that causes a warning

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -155,7 +155,6 @@ const extensions = [
   FontFamily,
   Heading,
   FontSize,
-  Heading,
   Bold,
   Italic,
   TextUnderline,


### PR DESCRIPTION
Heading in src/extensions/Heading/Heading.ts extends TipTap’s built-in heading, but was registered twice and caused a warning