### PR TITLE
fix(i18n): localize drag-handle tooltips (insert block & grip)

### DIFF
--- a/src/components/Bubble/RichTextBubbleMenuDragHandle.tsx
+++ b/src/components/Bubble/RichTextBubbleMenuDragHandle.tsx
@@ -161,12 +161,17 @@ export function RichTextBubbleMenuDragHandle() {
       pluginKey={'RichTextBubbleMenuDragHandle'}
     >
       <div className='richtext-flex richtext-items-center richtext-gap-0.5'>
-        <ActionButton action={handleAdd} disabled={!editable} icon='Plus' tooltip='Insert block' />
+        <ActionButton
+          action={handleAdd}
+          disabled={!editable}
+          icon='Plus'
+          tooltip={t('editor.draghandle.insertBlock')}
+        />
 
         <ActionButton
           disabled={!editable}
           icon='Grip'
-          tooltip='Click for options, Hold for drag'
+          tooltip={t('editor.draghandle.grip')}
           action={(e) => {
             e.preventDefault();
             e.stopPropagation();

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -12,6 +12,8 @@ const locale = {
   'editor.settings': 'Settings',
   'editor.table_of_content': 'Table of Content',
   'editor.draghandle.tooltip': 'Modify',
+  'editor.draghandle.insertBlock': 'Insert block',
+  'editor.draghandle.grip': 'Click for options, hold to drag',
   'editor.copyToClipboard': 'CopyToClipboard',
   'editor.slash': "Press '/' for commands",
   'editor.slash.empty': 'No Result',

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -12,6 +12,8 @@ const locale = {
   'editor.settings': 'Asetukset',
   'editor.table_of_content': 'Sisällysluettelo',
   'editor.draghandle.tooltip': 'Muokkaa',
+  'editor.draghandle.insertBlock': 'Lisää lohko',
+  'editor.draghandle.grip': 'Napsauta valikkoon, pidä pohjassa siirtääksesi',
   'editor.copyToClipboard': 'Kopioi leikepöydälle',
   'editor.slash': "Paina '/' nähdäksesi komennot",
   'editor.slash.empty': 'Ei tuloksia',

--- a/src/locales/hu.ts
+++ b/src/locales/hu.ts
@@ -12,6 +12,8 @@ const locale = {
   'editor.settings': 'Beállítások',
   'editor.table_of_content': 'Tartalomjegyzék',
   'editor.draghandle.tooltip': 'Módosítás',
+  'editor.draghandle.insertBlock': 'Blokk beszúrása',
+  'editor.draghandle.grip': 'Kattintson a menühöz, tartsa nyomva az áthúzáshoz',
   'editor.copyToClipboard': 'Másolás vágólapra',
   'editor.slash': "Nyomja meg a '/' gombot a parancsokhoz",
   'editor.slash.empty': 'Nincs találat',

--- a/src/locales/pt-br.ts
+++ b/src/locales/pt-br.ts
@@ -12,6 +12,8 @@ const locale = {
   'editor.settings': 'Configurações',
   'editor.table_of_content': 'Tabela de conteúdos',
   'editor.draghandle.tooltip': 'Modificar',
+  'editor.draghandle.insertBlock': 'Inserir bloco',
+  'editor.draghandle.grip': 'Clique para opções, segure para arrastar',
   'editor.copyToClipboard': 'Copiar para a área de transferência',
   'editor.slash': "Pressione '/' para comandos",
   'editor.slash.empty': 'Nenhum resultado',

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -12,6 +12,8 @@ const locale = {
   'editor.settings': 'Cài đặt',
   'editor.table_of_content': 'Mục lục',
   'editor.draghandle.tooltip': 'Sửa đổi',
+  'editor.draghandle.insertBlock': 'Chèn khối',
+  'editor.draghandle.grip': 'Nhấn để mở menu, giữ để kéo',
   'editor.copyToClipboard': 'CopyToClipboard',
   'editor.slash': "Nhấn '/' để biết lệnh",
   'editor.slash.empty': 'Không có kết quả',

--- a/src/locales/zh-cn.ts
+++ b/src/locales/zh-cn.ts
@@ -12,6 +12,8 @@ const locale = {
   'editor.settings': '设置',
   'editor.table_of_content': '目录',
   'editor.draghandle.tooltip': '修改',
+  'editor.draghandle.insertBlock': '插入块',
+  'editor.draghandle.grip': '点击打开菜单，按住可拖拽',
   'editor.copyToClipboard': '复制到剪贴板',
   'editor.slash': "按 '/' 使用命令",
   'editor.slash.empty': '无结果',


### PR DESCRIPTION
### Summary

`RichTextBubbleMenuDragHandle` used hard-coded English strings for the **“+”** (slash / insert) and **grip** buttons. When the editor locale is set to `zh_CN` (or others), those tooltips stayed in English. This PR wires them through the existing locale system (`t(...)`) and adds the corresponding keys to all locale files.

### Changes

- **`src/components/Bubble/RichTextBubbleMenuDragHandle.tsx`**  
  - Replace `tooltip='Insert block'` with `tooltip={t('editor.draghandle.insertBlock')}`.  
  - Replace `tooltip='Click for options, Hold for drag'` with `tooltip={t('editor.draghandle.grip')}` (punctuation aligned with other locales: “hold to drag”).
- **`src/locales/*.ts`**  
  - Add `editor.draghandle.insertBlock` and `editor.draghandle.grip` for `en`, `zh-cn`, `fi`, `hu`, `pt-br`, and `vi`.

### Motivation

Keeps slash / block insertion UX consistent with the rest of the editor (e.g. `editor.draghandle.tooltip`, `editor.slash.*`).

### How to test

1. Run the playground or any app using `RichTextProvider` + `RichTextBubbleMenuDragHandle`.  
2. Call `localeActions.setLang('zh_CN')` (or switch language in your demo).  
3. Hover the **+** and **grip** icons on the drag handle: tooltips should match the selected language.

