### PR TITLE
fix: sync highlight picker with selection color

### DIFF
--- a/src/extensions/Highlight/Highlight.ts
+++ b/src/extensions/Highlight/Highlight.ts
@@ -47,7 +47,11 @@ export const Highlight =
               }
               editor.chain().focus().unsetHighlight().run();
             },
-            isActive: () => editor.isActive('highlight') || false,
+            isActive: () => {
+              const { color } = editor.getAttributes('highlight');
+
+              return color;
+            },
             disabled: false,
             shortcutKeys: extension.options.shortcutKeys ?? ['⇧', 'mod', 'H'],
             tooltip: t('editor.highlight.tooltip'),

--- a/src/extensions/Highlight/components/RichTextHighlight.tsx
+++ b/src/extensions/Highlight/components/RichTextHighlight.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { ActionButton, ColorPicker } from '@/components';
 import { IconComponent } from '@/components/icons';
@@ -19,12 +19,16 @@ export function RichTextHighlight() {
     shortcutKeys,
   } = buttonProps?.componentProps ?? {};
 
-  const { editorDisabled } = useActive(isActive);
+  const { disabled, dataState } = useActive(isActive);
 
   const [selectedColor, setSelectedColor] = useState<any>(defaultColor);
 
+  useEffect(() => {
+    setSelectedColor(dataState);
+  }, [dataState]);
+
   function onChange(color: any) {
-    if (editorDisabled) return;
+    if (disabled) return;
 
     if (action) {
       action?.(color);
@@ -39,19 +43,19 @@ export function RichTextHighlight() {
   return (
     <ColorPicker
       colors={colors}
-      disabled={editorDisabled}
+      disabled={disabled}
       highlight
       onChange={onChange}
       value={selectedColor}
     >
       <ActionButton
-        disabled={editorDisabled}
+        disabled={disabled}
         tooltip={tooltip}
         // tooltipOptions={tooltipOptions}
         shortcutKeys={shortcutKeys}
       >
         <span className='richtext-flex richtext-items-center richtext-justify-center richtext-gap-[4px] richtext-text-sm'>
-          <IconHighlightFill fill={selectedColor} />
+          <IconHighlightFill fill={dataState} />
 
           <IconComponent
             className='!richtext-h-3 !richtext-w-3 richtext-text-zinc-500'


### PR DESCRIPTION
## Summary

This PR updates the Highlight extension so its toolbar and bubble color picker stay in sync with the currently selected text highlight color, matching the existing behavior of the Color extension.

## Changes

- Read the current highlight color from `editor.getAttributes('highlight')`.
- Pass the selected highlight color through `useActive`.
- Sync the Highlight color picker value when the editor selection changes.
- Update the Highlight toolbar/bubble icon fill to reflect the selected text's highlight color.
- Keep the existing behavior where user-picked colors are stored separately for repeated use and shortcuts.

## Why

The Color extension already reflects the selected text color in both the toolbar and bubble menu. Highlight previously only tracked whether a highlight mark was active, so the UI could not show the actual selected highlight color.

This made Color and Highlight behave inconsistently and made it harder to reason about future color application logic.

## Validation

- Ran TypeScript type checking:

```bash
pnpm type-check

- Ran lint:

pnpm lint

Lint completed with existing warnings in the project.

- Checked diff whitespace:

git diff --check -- src/extensions/Highlight/Highlight.ts src/extensions/Highlight/components/RichTextHighlight.tsx

Notes

This PR only updates Highlight color state synchronization. It does not change the existing Color extension behavior or introduce new UI components.