### PR TITLE
feat: add format painter extension

### DIFF
--- a/docs/.vitepress/locale.ts
+++ b/docs/.vitepress/locale.ts
@@ -123,6 +123,7 @@ export function getLocaleConfig(lang: string) {
         { text: 'ExportWord', link: '/extensions/ExportWord/index.md' },
         { text: 'FontFamily', link: '/extensions/FontFamily/index.md' },
         { text: 'FontSize', link: '/extensions/FontSize/index.md' },
+        { text: 'FormatPainter', link: '/extensions/FormatPainter/index.md' },
         { text: 'Heading', link: '/extensions/Heading/index.md' },
         { text: 'Highlight', link: '/extensions/Highlight/index.md' },
         { text: 'History', link: '/extensions/History/index.md' },

--- a/docs/extensions/FormatPainter/index.md
+++ b/docs/extensions/FormatPainter/index.md
@@ -1,14 +1,16 @@
 ---
-description: FontSize
+description: FormatPainter
 
 next:
-  text: FormatPainter
-  link: /extensions/FormatPainter/index.md
+  text: Heading
+  link: /extensions/Heading/index.md
 ---
 
-# Font Size
+# Format Painter
 
-The Font Size extension allows you to change the font size of your editor.
+The Format Painter extension allows you to copy text marks from one selection and apply them to another selection.
+
+This is a custom extension built on top of Tiptap and ProseMirror. It copies inline text marks such as bold, italic, underline, text color, highlight, font family, and font size. Link marks are skipped to avoid copying link targets unexpectedly.
 
 ## Usage
 
@@ -25,7 +27,7 @@ import { TextStyle } from '@tiptap/extension-text-style';
 import { ListItem } from '@tiptap/extension-list';
 
 // Extension
-import { FontSize, RichTextFontSize } from 'reactjs-tiptap-editor/fontsize'; // [!code ++]
+import { FormatPainter, RichTextFormatPainter } from 'reactjs-tiptap-editor/formatpainter'; // [!code ++]
 // ... other extensions
 
 
@@ -49,12 +51,12 @@ const extensions = [
 
   ...
   // Import Extensions Here
-  FontSize// [!code ++]
+  FormatPainter// [!code ++]
 ];
 
 const RichTextToolbar = () => {
   return (
-    <RichTextFontSize /> {/* [!code ++] */}
+    <RichTextFormatPainter /> {/* [!code ++] */}
   )
 }
 
@@ -78,25 +80,29 @@ const App = () => {
 };
 ```
 
-## Options
+## Behavior
 
-### fontSizes
+1. Select text that already has the formatting you want to copy.
+2. Click the format painter button.
+3. Select the target text.
+4. The copied marks are applied to the target selection and the format painter turns off automatically.
 
-Type: `(string | { value: string; name: string })[]`
+Press `Escape` or click the button again to cancel the format painter state.
 
-```js
-import { DEFAULT_FONT_SIZE_LIST, FontSize } from 'reactjs-tiptap-editor/fontsize';
+## Commands
 
-FontSize.configure({
-  fontSizes: [
-    // Use default font size list
-    ...DEFAULT_FONT_SIZE_LIST,
-    // Two formats
-    //   1. string
-    //   2. { name: 'xxx', value: 'xxx' }
+### setPainter
 
-    '10px',
-    { name: '200 pixel', value: '200px' },
-  ],
-});
+Copies the current selection marks and enables format painter mode.
+
+```ts
+editor.commands.setPainter()
+```
+
+### unsetPainter
+
+Cancels format painter mode.
+
+```ts
+editor.commands.unsetPainter()
 ```

--- a/package.json
+++ b/package.json
@@ -99,6 +99,9 @@
       "./fontsize": [
         "./lib/extensions/FontSize/index.d.ts"
       ],
+      "./formatpainter": [
+        "./lib/extensions/FormatPainter/index.d.ts"
+      ],
       "./heading": [
         "./lib/extensions/Heading/index.d.ts"
       ],
@@ -397,6 +400,16 @@
       "import": {
         "types": "./lib/extensions/FontSize/index.d.ts",
         "default": "./lib/FontSize.js"
+      }
+    },
+    "./formatpainter": {
+      "require": {
+        "types": "./lib/extensions/FormatPainter/index.d.ts",
+        "default": "./lib/FormatPainter.cjs"
+      },
+      "import": {
+        "types": "./lib/extensions/FormatPainter/index.d.ts",
+        "default": "./lib/FormatPainter.js"
       }
     },
     "./heading": {

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -65,6 +65,7 @@ import { ExportPdf, RichTextExportPdf } from 'reactjs-tiptap-editor/exportpdf';
 import { ExportWord, RichTextExportWord } from 'reactjs-tiptap-editor/exportword';
 import { FontFamily, RichTextFontFamily } from 'reactjs-tiptap-editor/fontfamily';
 import { FontSize, RichTextFontSize } from 'reactjs-tiptap-editor/fontsize';
+import { FormatPainter, RichTextFormatPainter } from 'reactjs-tiptap-editor/formatpainter';
 import { Heading, RichTextHeading } from 'reactjs-tiptap-editor/heading';
 import { Highlight, RichTextHighlight } from 'reactjs-tiptap-editor/highlight';
 // build extensions
@@ -209,6 +210,7 @@ const extensions = [
   FontFamily,
   Heading,
   FontSize,
+  FormatPainter,
   Bold,
   Italic,
   TextUnderline,
@@ -560,6 +562,7 @@ const RichTextToolbar = () => {
       <RichTextRedo />
       <RichTextSearchAndReplace />
       <RichTextClear />
+      <RichTextFormatPainter />
       <RichTextFontFamily />
       <RichTextHeading />
       <RichTextFontSize />

--- a/scripts/extensions.json
+++ b/scripts/extensions.json
@@ -126,6 +126,13 @@
     ]
   },
   {
+    "name": "FormatPainter.ts",
+    "package": "FormatPainter",
+    "alias": [
+      "FormatPainter"
+    ]
+  },
+  {
     "name": "Heading.ts",
     "package": "Heading",
     "alias": [

--- a/skills/reactjs-tiptap-editor/references/extension-map.md
+++ b/skills/reactjs-tiptap-editor/references/extension-map.md
@@ -36,6 +36,7 @@ Load this before adding imports, toolbar buttons, bubble menus, or extension arr
 | Export Word | `reactjs-tiptap-editor/exportword` | `ExportWord`, `RichTextExportWord` |
 | Font family | `reactjs-tiptap-editor/fontfamily` | `FontFamily`, `RichTextFontFamily` |
 | Font size | `reactjs-tiptap-editor/fontsize` | `FontSize`, `RichTextFontSize` |
+| Format painter | `reactjs-tiptap-editor/formatpainter` | `FormatPainter`, `RichTextFormatPainter` |
 | Heading | `reactjs-tiptap-editor/heading` | `Heading`, `RichTextHeading` |
 | Highlight | `reactjs-tiptap-editor/highlight` | `Highlight`, `RichTextHighlight` |
 | History | `reactjs-tiptap-editor/history` | `History`, `RichTextUndo`, `RichTextRedo` |

--- a/src/extensions/FormatPainter/FormatPainter.ts
+++ b/src/extensions/FormatPainter/FormatPainter.ts
@@ -1,0 +1,177 @@
+import { Extension } from '@tiptap/core';
+import type { Mark, MarkType } from '@tiptap/pm/model';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { EditorState, Transaction } from '@tiptap/pm/state';
+
+import { ActionButton } from '@/components';
+
+import type { GeneralOptions } from '@/types';
+
+export * from './components/RichTextFormatPainter';
+
+export type FormatPainterOptions = GeneralOptions<unknown>;
+
+type FormatPainterState = Mark[];
+type FormatPainterAction = { type: 'start'; marks: Mark[] } | { type: 'end' };
+
+const SKIPPED_MARK_NAMES = new Set(['link']);
+
+export const formatPainterPluginKey = new PluginKey<FormatPainterState>('format-painter');
+
+function getPainterMarks(state: EditorState) {
+  return formatPainterPluginKey.getState(state) ?? [];
+}
+
+function getMarksFromSelection(state: EditorState) {
+  const { selection, storedMarks } = state;
+  const marks: Mark[] = [];
+
+  if (storedMarks?.length || selection.empty) {
+    const sourceMarks = storedMarks ?? selection.$from.marks();
+    sourceMarks.forEach((mark) => {
+      if (!SKIPPED_MARK_NAMES.has(mark.type.name)) marks.push(mark);
+    });
+    return marks;
+  }
+
+  state.doc.nodesBetween(selection.from, selection.to, (node) => {
+    if (!node.isText || marks.length > 0) return true;
+
+    node.marks.forEach((mark) => {
+      if (!SKIPPED_MARK_NAMES.has(mark.type.name)) marks.push(mark);
+    });
+    return false;
+  });
+
+  return marks;
+}
+
+function applyMarksToSelection(tr: Transaction, state: EditorState, marks: Mark[]) {
+  const { from, to } = state.selection;
+
+  Object.values(state.schema.marks).forEach((markType: MarkType) => {
+    if (!SKIPPED_MARK_NAMES.has(markType.name)) {
+      tr = tr.removeMark(from, to, markType);
+    }
+  });
+
+  marks.forEach((mark) => {
+    tr = tr.addMark(from, to, mark);
+  });
+
+  return tr;
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    painter: {
+      setPainter: () => ReturnType
+      unsetPainter: () => ReturnType
+    }
+  }
+}
+
+export const FormatPainter = /* @__PURE__ */ Extension.create<FormatPainterOptions>({
+  name: 'painter',
+
+  //@ts-expect-error
+  addOptions() {
+    return {
+      ...this.parent?.(),
+      button: ({ editor, t }) => ({
+        component: ActionButton,
+        componentProps: {
+          action: () => {
+            if (getPainterMarks(editor.state).length > 0) {
+              editor.commands.unsetPainter();
+              return;
+            }
+
+            editor.commands.setPainter();
+          },
+          isActive: () => getPainterMarks(editor.state).length > 0,
+          icon: 'PaintRoller',
+          tooltip: t('editor.format'),
+        },
+      }),
+    };
+  },
+
+  addCommands() {
+    return {
+      setPainter:
+        () =>
+        ({ dispatch, state }) => {
+          const marks = getMarksFromSelection(state);
+
+          if (!marks.length) {
+            dispatch?.(state.tr.setMeta(formatPainterPluginKey, { type: 'end' }));
+            return false;
+          }
+
+          dispatch?.(
+            state.tr.setMeta(formatPainterPluginKey, {
+              type: 'start',
+              marks,
+            } satisfies FormatPainterAction)
+          );
+
+          return true;
+        },
+      unsetPainter:
+        () =>
+        ({ dispatch, state }) => {
+          dispatch?.(state.tr.setMeta(formatPainterPluginKey, { type: 'end' }));
+
+          return true;
+        },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin<FormatPainterState>({
+        key: formatPainterPluginKey,
+        state: {
+          init: () => [],
+          apply: (tr, marks) => {
+            const action = tr.getMeta(formatPainterPluginKey) as FormatPainterAction | undefined;
+
+            if (action?.type === 'start') return action.marks;
+            if (action?.type === 'end') return [];
+
+            return marks;
+          },
+        },
+        props: {
+          handleDOMEvents: {
+            keydown: (view, event) => {
+              if (event.key !== 'Escape' || getPainterMarks(view.state).length === 0) return false;
+
+              view.dispatch(view.state.tr.setMeta(formatPainterPluginKey, { type: 'end' }));
+              return true;
+            },
+            mousedown: (view) => {
+              const marks = getPainterMarks(view.state);
+
+              if (!marks.length) return false;
+
+              const mouseup = () => {
+                document.removeEventListener('mouseup', mouseup);
+
+                const { state } = view;
+                const { selection } = state;
+                const tr = selection.empty ? state.tr : applyMarksToSelection(state.tr, state, marks);
+
+                view.dispatch(tr.setMeta(formatPainterPluginKey, { type: 'end' }));
+              };
+
+              document.addEventListener('mouseup', mouseup);
+              return false;
+            },
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/src/extensions/FormatPainter/components/RichTextFormatPainter.tsx
+++ b/src/extensions/FormatPainter/components/RichTextFormatPainter.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+
+import { ActionButton } from '@/components';
+import { FormatPainter } from '@/extensions/FormatPainter/FormatPainter';
+import { useButtonProps } from '@/hooks/useButtonProps';
+import { useEditorInstance } from '@/store/editor';
+import { useEditableEditor } from '@/store/store';
+
+export function RichTextFormatPainter() {
+  const editor = useEditorInstance();
+  const editable = useEditableEditor();
+  const buttonProps = useButtonProps(FormatPainter.name);
+
+  const {
+    icon = undefined,
+    tooltip = undefined,
+    shortcutKeys = undefined,
+    tooltipOptions = {},
+    action = undefined,
+    isActive = undefined,
+  } = buttonProps?.componentProps ?? {};
+
+  const [dataState, setDataState] = useState(() => !!isActive?.());
+
+  useEffect(() => {
+    if (!editor || !isActive) return;
+
+    const listener = () => {
+      setDataState(!!isActive());
+    };
+
+    listener();
+
+    editor.on('selectionUpdate', listener);
+    editor.on('transaction', listener);
+
+    return () => {
+      editor.off('selectionUpdate', listener);
+      editor.off('transaction', listener);
+    };
+  }, [editor, isActive]);
+
+  const disabled = !editable || !editor;
+
+  const onAction = () => {
+    if (disabled) return;
+
+    action?.();
+  };
+
+  if (!buttonProps) {
+    return <></>;
+  }
+
+  return (
+    <ActionButton
+      action={onAction}
+      dataState={dataState}
+      disabled={disabled}
+      icon={icon}
+      shortcutKeys={shortcutKeys}
+      tooltip={tooltip}
+      tooltipOptions={tooltipOptions}
+    />
+  );
+}

--- a/src/extensions/FormatPainter/index.ts
+++ b/src/extensions/FormatPainter/index.ts
@@ -1,0 +1,1 @@
+export * from './FormatPainter';

--- a/src/locales/pt-br.ts
+++ b/src/locales/pt-br.ts
@@ -6,7 +6,7 @@ const locale = {
   'editor.default': 'Padrão',
   'editor.recent': 'Usado recentemente',
   'editor.nofill': 'Sem preenchimento',
-  'editor.format': 'Format Painter',
+  'editor.format': 'Pincel de formatação',
   'editor.delete': 'Deletar',
   'editor.edit': 'Editar',
   'editor.settings': 'Configurações',

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -6,7 +6,7 @@ const locale = {
   'editor.default': 'Mặc định',
   'editor.recent': 'Đã sử dụng gần đây',
   'editor.nofill': 'Không tô',
-  'editor.format': 'Format Painter',
+  'editor.format': 'Sao chép định dạng',
   'editor.delete': 'Xóa',
   'editor.edit': 'Chỉnh sửa',
   'editor.settings': 'Cài đặt',

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type ExtensionNameKeys =
   | 'strike'
   | 'color'
   | 'highlight'
+  | 'painter'
   | 'heading'
   | 'textAlign'
   | 'bulletList'


### PR DESCRIPTION
## Summary

This PR adds the Format Painter extension back to the editor using the current extension architecture.

The new Format Painter allows users to copy inline text formatting from one selection and apply it to another selection, matching the expected rich text editing workflow.

## Changes

- Add a new `FormatPainter` extension.
- Add the `RichTextFormatPainter` toolbar component.
- Add package subpath export support for:

  ```ts
  reactjs-tiptap-editor/formatpainter

- Register painter in the extension name types.
- Add Format Painter to the playground toolbar and extension list.
- Add Format Painter to scripts/extensions.json.
- Add Format Painter to the project extension map reference.
- Add documentation for the Format Painter extension.
- Add Format Painter to the docs sidebar.
- Update the FontSize docs navigation to point to FormatPainter before Heading.
- Update editor.format translations for Portuguese Brazilian and Vietnamese.

Behavior

The Format Painter works as follows:

1. Select text that already has the formatting to copy.
2. Click the Format Painter button.
3. Select the target text.
4. The copied inline marks are applied to the target selection.
5. The Format Painter state is cleared automatically.

Users can also cancel the active Format Painter state by pressing Escape or clicking the button again.

The implementation skips link marks to avoid unexpectedly copying link targets.

Validation

- pnpm type-check
- pnpm docs:build
- Commit hook ran oxlint --fix

The lint step completed with existing project warnings.