### PR TITLE
fix: close image dialog after crop upload

### DIFF
--- a/src/components/SlashDialogTrigger/RenderDialogUploadImage.tsx
+++ b/src/components/SlashDialogTrigger/RenderDialogUploadImage.tsx
@@ -39,6 +39,7 @@ export function RenderDialogUploadImage() {
   const { editorDisabled } = useToggleActive();
 
   const [open, setOpen] = useState(false);
+  const [isCropDialogOpen, setIsCropDialogOpen] = useState(false);
 
   const EVENT_ID = EVENTS.UPLOAD_IMAGE((editor as any).id);
 
@@ -155,8 +156,16 @@ export function RenderDialogUploadImage() {
   }
 
   return (
-    <Dialog onOpenChange={setOpen} open={open}>
-      <DialogContent>
+    <Dialog
+      onOpenChange={(open) => {
+        setOpen(open);
+        if (!open) {
+          setIsCropDialogOpen(false);
+        }
+      }}
+      open={open}
+    >
+      <DialogContent className={isCropDialogOpen ? 'richtext-hidden' : undefined}>
         <DialogTitle>{t('editor.image.dialog.title')}</DialogTitle>
 
         <Tabs
@@ -219,8 +228,12 @@ export function RenderDialogUploadImage() {
                 editor={editor}
                 imageInline={imageInline}
                 onClose={() => {
+                  setOpen(false);
+                  setIsCropDialogOpen(false);
                   setAlt('');
+                  setImageInline(defaultInline);
                 }}
+                onOpenChange={setIsCropDialogOpen}
               />
             </div>
 

--- a/src/extensions/Image/components/ImageCropper.tsx
+++ b/src/extensions/Image/components/ImageCropper.tsx
@@ -16,7 +16,7 @@ import { useLocale } from '@/locales';
 import { dataURLtoFile, readImageAsBase64 } from '@/utils/file';
 import { validateFiles } from '@/utils/validateFile';
 
-export function ImageCropper({ editor, imageInline, onClose, disabled, alt }: any) {
+export function ImageCropper({ editor, imageInline, onClose, onOpenChange, disabled, alt }: any) {
   const { t } = useLocale();
   const { toast } = useToast();
 
@@ -74,6 +74,27 @@ export function ImageCropper({ editor, imageInline, onClose, disabled, alt }: an
     return canvas.toDataURL('image/png', 1.0);
   }
 
+  const resetFileInput = React.useCallback(() => {
+    if (fileInput.current) {
+      fileInput.current.value = '';
+    }
+  }, []);
+
+  const handleDialogOpenChange = React.useCallback(
+    (open: boolean) => {
+      setDialogOpen(open);
+      onOpenChange?.(open);
+
+      if (!open) {
+        setCrop(undefined);
+        setCroppedImageUrl('');
+        setUrlUpload({ src: '', file: null });
+        resetFileInput();
+      }
+    },
+    [onOpenChange, resetFileInput]
+  );
+
   const onCrop = React.useCallback(async () => {
     if (isCropping) return;
 
@@ -90,14 +111,7 @@ export function ImageCropper({ editor, imageInline, onClose, disabled, alt }: an
 
       editor.chain().focus().setImageInline({ src, inline: imageInline, alt }).run();
 
-      setDialogOpen(false);
-
-      setUrlUpload({
-        src: '',
-        file: null,
-      });
-
-      resetFileInput();
+      handleDialogOpenChange(false);
       onClose();
     } catch (error) {
       console.error('Error cropping image', error);
@@ -105,8 +119,10 @@ export function ImageCropper({ editor, imageInline, onClose, disabled, alt }: an
       setIsCropping(false);
     }
   }, [
+    alt,
     croppedImageUrl,
     editor,
+    handleDialogOpenChange,
     imageInline,
     isCropping,
     onClose,
@@ -142,17 +158,11 @@ export function ImageCropper({ editor, imageInline, onClose, disabled, alt }: an
     const file = validFiles[0];
     const base64 = await readImageAsBase64(file);
 
-    setDialogOpen(true);
+    handleDialogOpenChange(true);
     setUrlUpload({
       src: base64.src,
       file,
     });
-  };
-
-  const resetFileInput = () => {
-    if (fileInput.current) {
-      fileInput.current.value = '';
-    }
   };
 
   return (
@@ -166,16 +176,7 @@ export function ImageCropper({ editor, imageInline, onClose, disabled, alt }: an
         {t('editor.image.dialog.tab.uploadCrop')}
       </Button>
 
-      <Dialog
-        open={dialogOpen}
-        onOpenChange={(open) => {
-          setDialogOpen(open);
-          if (!open) {
-            setUrlUpload({ src: '', file: null });
-            resetFileInput();
-          }
-        }}
-      >
+      <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
         <DialogTrigger />
 
         <DialogContent>
@@ -198,12 +199,7 @@ export function ImageCropper({ editor, imageInline, onClose, disabled, alt }: an
             <Button
               disabled={isCropping}
               onClick={() => {
-                setDialogOpen(false);
-                setUrlUpload({
-                  src: '',
-                  file: null,
-                });
-                resetFileInput();
+                handleDialogOpenChange(false);
               }}
             >
               {t('editor.imageUpload.cancel')}

--- a/src/extensions/Image/components/RichTextImage.tsx
+++ b/src/extensions/Image/components/RichTextImage.tsx
@@ -35,6 +35,7 @@ export function RichTextImage() {
   const { editorDisabled } = useToggleActive();
 
   const [open, setOpen] = useState(false);
+  const [isCropDialogOpen, setIsCropDialogOpen] = useState(false);
 
   const [isUploading, setIsUploading] = useState(false);
   const extension = useExtension(Image.name);
@@ -147,7 +148,15 @@ export function RichTextImage() {
   }
 
   return (
-    <Dialog onOpenChange={setOpen} open={open}>
+    <Dialog
+      onOpenChange={(open) => {
+        setOpen(open);
+        if (!open) {
+          setIsCropDialogOpen(false);
+        }
+      }}
+      open={open}
+    >
       <DialogTrigger asChild>
         <ActionButton
           disabled={editorDisabled}
@@ -160,7 +169,7 @@ export function RichTextImage() {
         />
       </DialogTrigger>
 
-      <DialogContent>
+      <DialogContent className={isCropDialogOpen ? 'richtext-hidden' : undefined}>
         <DialogTitle>{t('editor.image.dialog.title')}</DialogTitle>
 
         <Tabs
@@ -223,8 +232,12 @@ export function RichTextImage() {
                 editor={editor}
                 imageInline={imageInline}
                 onClose={() => {
+                  setOpen(false);
+                  setIsCropDialogOpen(false);
                   setAlt('');
+                  setImageInline(defaultInline);
                 }}
+                onOpenChange={setIsCropDialogOpen}
               />
             </div>
 


### PR DESCRIPTION
## Summary

Fix the image upload crop flow so the original image dialog no longer remains visible after opening or completing the crop dialog.

## Problem

When users clicked **Upload & Crop** in the image plugin, the crop dialog opened successfully, but the original **Add Image** dialog stayed visible behind it. After cropping and uploading, the editor content was updated correctly, but the original dialog still remained open, which created an inconsistent and confusing user experience.

## Root Cause

The crop dialog was managed inside `ImageCropper`, while the parent image dialog was managed separately by `RichTextImage` and `RenderDialogUploadImage`.

Previously, `ImageCropper` only closed its own dialog after a successful crop upload and called `onClose()`. However, the parent `onClose` handler only reset the alt text and did not close the parent image dialog.

## Changes

- Added crop dialog open-state propagation from `ImageCropper` to its parent components.
- Hid the parent image dialog content while the crop dialog is open.
- Closed the parent image dialog after a successful crop upload.
- Reset image dialog state after crop upload completion:
  - `alt`
  - `imageInline`
  - crop state
  - cropped image URL
  - selected file input
- Applied the same behavior to both image entry points:
  - toolbar image button
  - slash command upload image dialog

## Files Changed

- `src/extensions/Image/components/ImageCropper.tsx`
  - Added `onOpenChange` support.
  - Centralized crop dialog close cleanup.
  - Reset crop-related state when the crop dialog closes.
  - Notify parent dialog when crop dialog opens or closes.

- `src/extensions/Image/components/RichTextImage.tsx`
  - Track crop dialog state.
  - Hide the parent image dialog while cropping.
  - Close and reset the parent dialog after successful crop upload.

- `src/components/SlashDialogTrigger/RenderDialogUploadImage.tsx`
  - Applied the same crop dialog lifecycle handling for slash command image uploads.

## Verification

- Ran TypeScript type check:

  ```bash
  pnpm type-check

  Passed.

- Checked formatting for changed files:

pnpm exec oxfmt --check src/extensions/Image/components/ImageCropper.tsx src/extensions/Image/components/RichTextImage.tsx src/components/SlashDialogTrigger/RenderDialogUploadImage.tsx

- Passed.
- Ran lint check on changed files:

pnpm exec oxlint src/extensions/Image/components/ImageCropper.tsx src/extensions/Image/components/RichTextImage.tsx src/components/SlashDialogTrigger/RenderDialogUploadImage.tsx

- No blocking errors. Existing no-explicit-any warnings remain consistent with surrounding code.

Expected Behavior

- Clicking Upload & Crop opens the crop dialog without leaving the original image dialog visibly stacked behind it.
- Cancelling crop returns the user to the original image dialog.
- Completing crop upload inserts the image and closes both the crop dialog and the original image dialog.