### PR TITLE
fix: stabilize image HTML round trip

### DIFF
--- a/src/extensions/Image/Image.ts
+++ b/src/extensions/Image/Image.ts
@@ -35,6 +35,18 @@ export const DEFAULT_OPTIONS: any = {
   enableAlt: true,
 };
 
+function parseBooleanHTMLAttribute(value: string | boolean | null | undefined): boolean | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return value === true || value === '' || value === 'true';
+}
+
+function getBooleanHTMLAttribute(value: string | boolean | null | undefined): boolean {
+  return parseBooleanHTMLAttribute(value) ?? false;
+}
+
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     imageUpload: {
@@ -141,10 +153,10 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
       },
       inline: {
         default: false,
-        parseHTML: (element) => Boolean(element.getAttribute('inline')),
+        parseHTML: (element) => parseBooleanHTMLAttribute(element.getAttribute('inline')),
         renderHTML: (attributes) => {
           return {
-            inline: attributes.inline,
+            inline: attributes.inline ? 'true' : null,
           };
         },
       },
@@ -191,14 +203,24 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
   },
   renderHTML({ HTMLAttributes }) {
     const { flipX, flipY, align, inline } = HTMLAttributes;
-    const inlineFloat = inline && (align === 'left' || align === 'right');
+    const isInline = getBooleanHTMLAttribute(inline);
+    const inlineFloat = isInline && (align === 'left' || align === 'right');
 
     const transformStyle =
       flipX || flipY
         ? `transform: rotateX(${flipX ? '180' : '0'}deg) rotateY(${flipY ? '180' : '0'}deg);`
         : '';
 
-    const textAlignStyle = inlineFloat ? '' : `text-align: ${align};`;
+    const textAlignStyle =
+      !isInline && align === 'center'
+        ? 'margin: 0 auto;'
+        : !isInline && align === 'right'
+          ? 'margin-left: auto;'
+          : !isInline
+            ? 'margin-right: auto;'
+            : '';
+
+    const displayStyle = isInline ? '' : 'display: block;';
 
     const floatStyle = inlineFloat ? `float: ${align};` : '';
 
@@ -208,12 +230,15 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
         : 'margin: 1em 0 1em 1em;'
       : '';
 
-    const style = `${floatStyle}${marginStyle}${transformStyle}`;
+    const style = `${displayStyle}${textAlignStyle}${floatStyle}${marginStyle}${transformStyle}`;
+    const imageHTMLAttributes = {
+      ...HTMLAttributes,
+      inline: isInline ? 'true' : null,
+    };
 
     return [
-      inline ? 'span' : 'div',
+      'span',
       {
-        style: textAlignStyle,
         class: 'image',
       },
       [
@@ -221,10 +246,10 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
         mergeAttributes(
           {
             height: 'auto',
-            style,
+            style: style || null,
           },
           this.options.HTMLAttributes,
-          HTMLAttributes
+          imageHTMLAttributes
         ),
       ],
     ];
@@ -232,9 +257,9 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
   parseHTML() {
     return [
       {
-        tag: 'span.image img',
-        getAttrs: (img) => {
-          const element = img?.parentElement;
+        tag: 'span.image',
+        getAttrs: (element) => {
+          const img = element.querySelector('img');
 
           const width = img?.getAttribute('width');
 
@@ -246,8 +271,8 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
             alt: img?.getAttribute('alt'),
             caption: img?.getAttribute('caption'),
             width: width ? Number.parseInt(width, 10) : null,
-            align: img?.getAttribute('align') || element?.style?.textAlign || null,
-            inline: img?.getAttribute('inline') || false,
+            align: img?.getAttribute('align') || element.style.textAlign || null,
+            inline: getBooleanHTMLAttribute(img?.getAttribute('inline')),
             flipX: flipX === 'true',
             flipY: flipY === 'true',
           };
@@ -268,7 +293,7 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
             caption: img?.getAttribute('caption'),
             width: width ? Number.parseInt(width, 10) : null,
             align: img?.getAttribute('align') || element.style.textAlign || null,
-            inline: img?.getAttribute('inline') || false,
+            inline: getBooleanHTMLAttribute(img?.getAttribute('inline')),
             flipX: flipX === 'true',
             flipY: flipY === 'true',
           };

--- a/src/extensions/Image/components/ImageView.tsx
+++ b/src/extensions/Image/components/ImageView.tsx
@@ -45,7 +45,8 @@ function ImageView(props: any) {
   });
 
   const { align, inline } = props?.node?.attrs;
-  const inlineFloat = inline && (align === 'left' || align === 'right');
+  const isInline = inline === true || inline === 'true';
+  const inlineFloat = isInline && (align === 'left' || align === 'right');
 
   const imgAttrs = useMemo(() => {
     const { src, alt, width: w, height: h, flipX, flipY } = props?.node?.attrs;
@@ -70,7 +71,7 @@ function ImageView(props: any) {
         ...floatStyle,
       },
     };
-  }, [props?.node?.attrs]);
+  }, [props?.node?.attrs, inlineFloat, align]);
 
   const imageMaxStyle = useMemo(() => {
     const {
@@ -226,18 +227,18 @@ function ImageView(props: any) {
 
   return (
     <NodeViewWrapper
-      as={inline ? 'span' : 'div'}
+      as='span'
       className='image-view'
       style={{
         float: inlineFloat ? align : undefined,
         margin: inlineFloat ? (align === 'left' ? '1em 1em 1em 0' : '1em 0 1em 1em') : undefined,
-        display: inline ? 'inline' : 'block',
+        display: isInline ? 'inline' : 'block',
         textAlign: inlineFloat ? undefined : align,
         width: imgAttrs.style?.width ?? 'auto',
         ...(inlineFloat ? {} : imageMaxStyle),
       }}
     >
-      <div
+      <span
         data-drag-handle
         draggable='true'
         style={imageMaxStyle}
@@ -256,7 +257,7 @@ function ImageView(props: any) {
         />
 
         {props?.editor.view.editable && (props?.selected || resizing) && (
-          <div className='image-resizer'>
+          <span className='image-resizer'>
             {resizeDirections?.map((direction) => {
               return (
                 <span
@@ -266,9 +267,9 @@ function ImageView(props: any) {
                 ></span>
               );
             })}
-          </div>
+          </span>
         )}
-      </div>
+      </span>
     </NodeViewWrapper>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #277.

Fix abnormal blank lines around block-style images after repeatedly exporting editor HTML and loading it back into the editor.

This PR keeps the public `Image` extension API and the existing node name unchanged, but stabilizes the HTML round-trip behavior for both block-style and inline images.

## Root cause

The current `Image` extension schema is still an inline node:

```ts
group: 'inline'
inline: true
```

However, when `attrs.inline` was false, `renderHTML()` emitted a block wrapper like `div.image`. That creates an unstable mismatch between the ProseMirror schema and the generated HTML. When the exported HTML is loaded again, the browser DOM parser and ProseMirror normalize the structure, which can introduce empty paragraphs or additional wrappers around the image.

There was also an attribute parsing issue: `inline="false"` is a truthy string in JavaScript, so a block-style image could be parsed as inline on the next import.

## Changes

- Parse boolean HTML attributes explicitly for the image `inline` attr.
  - Only `true`, `"true"`, and an empty boolean attribute are treated as true.
  - `inline=false` is no longer serialized as `inline="false"`.
- Keep the image HTML wrapper schema-compatible by rendering `span.image` consistently.
- Apply block-style layout to the `img` itself using `display: block` and alignment margins instead of rendering a block wrapper for an inline schema node.
- Parse `span.image` as the canonical image wrapper.
- Keep parsing legacy `div[class=image]` so old HTML content can still be loaded.
- Update the React node view to use inline-compatible `span` wrappers while preserving block-like visual layout via styles.

## Backward compatibility

- Old HTML with `div.image` still loads and is normalized on export.
- Old ProseMirror JSON is not renamed or migrated in this PR. The node type remains `image`, so existing JSON content should continue to load.
- Inline images with `inline="true"` remain supported.

## Validation

- `pnpm type-check`
- `pnpm build:lib`
- `pnpm exec oxlint src/extensions/Image/Image.ts src/extensions/Image/components/ImageView.tsx`
  - This command reports existing warnings in these files/project style, but no blocking errors.
- Manual playground verification:
  - Loaded legacy block image HTML using `div.image`.
  - Repeated `editor.getHTML()` -> `editor.commands.setContent(html, false)` for 4 rounds.
  - Confirmed no empty paragraph nodes were added.
  - Confirmed no repeated nested `span.image` wrapping was added.
  - Confirmed inline images remain stable and keep `inline="true"` across repeated HTML round trips.

## Follow-up plan after this PR is merged

This PR is intentionally a low-risk stabilization fix. A larger schema cleanup can be done in later PRs.

Recommended follow-up PRs:

1. Add a true block image node behind the existing public API
   - Introduce a real block image node, for example `imageBlock`, with `group: 'block'` and `inline: false`.
   - Keep the existing `image` node for backward compatibility with saved JSON.
   - Route new block image insertions to `imageBlock` while keeping inline insertions on the current inline-compatible node.

2. Add JSON migration helpers
   - Provide an optional helper that converts old JSON content like a paragraph containing only `image` with `attrs.inline === false` into the new `imageBlock` node.
   - Do not force automatic migration until compatibility expectations are clear.

3. Add regression coverage for image HTML round trips
   - Add tests for legacy block HTML import/export.
   - Add tests for inline image import/export.
   - Add tests to ensure `inline="false"` is not emitted and not parsed as true.

4. Update docs
   - Document the difference between inline and block image behavior.
   - Document the backward-compatible migration path for consumers that store ProseMirror JSON.