### PR TITLE
Fix(video): show loading state during uploads

### DIFF
--- a/docs/extensions/Video/index.md
+++ b/docs/extensions/Video/index.md
@@ -47,6 +47,9 @@ const extensions = [
   // Import Extensions Here
   Video.configure({// [!code ++]
     resourceVideo: 'both',// [!code ++]
+    acceptMimes: ['video/mp4', 'video/webm'],// [!code ++]
+    maxSize: 100 * 1024 * 1024,// [!code ++]
+    multiple: false,// [!code ++]
     upload: async (file) => {// [!code ++]
       const formData = new FormData();// [!code ++]
       formData.append('file', file);// [!code ++]
@@ -124,8 +127,17 @@ interface VideoOptions extends GeneralOptions<VideoOptions> {
   /** Function for uploading files */
   upload?: (file: File) => Promise<string>;
 
-  /** Callback invoked when a video upload fails */
-  onError?: (error: { type: 'upload'; message: string; file?: File }) => void;
+  /** Whether multiple videos can be selected and uploaded at once */
+  multiple?: boolean;
+
+  /** Accepted video MIME types or file extensions */
+  acceptMimes?: string[];
+
+  /** Maximum size of a single video in bytes. No limit is applied when omitted. */
+  maxSize?: number;
+
+  /** Callback invoked when video validation or upload fails */
+  onError?: (error: { type: 'size' | 'type' | 'upload'; message: string; file?: File }) => void;
 
   /** The source URL of the video */
   resourceVideo: 'upload' | 'link' | 'both';
@@ -142,16 +154,19 @@ interface VideoOptions extends GeneralOptions<VideoOptions> {
 
 ## Options
 
-| Option            | Type                                                                | Description                                                                         | Required | Default                       |
-| ----------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------- | ----------------------------- |
-| `allowFullscreen` | `boolean`                                                           | Allows embedded videos to enter fullscreen mode.                                    | No       | `true`                        |
-| `frameborder`     | `boolean`                                                           | Displays a border around the embedded video frame.                                  | No       | `false`                       |
-| `width`           | `number \| string`                                                  | Sets the default video width.                                                       | No       | `VIDEO_SIZE.size-medium`      |
-| `HTMLAttributes`  | `Record<string, any>`                                               | Adds HTML attributes to the video wrapper.                                          | No       | `{ class: 'iframe-wrapper' }` |
-| `upload`          | `(file: File) => Promise<string>`                                   | Uploads a local video and resolves with the URL inserted into the editor.           | No       | None                          |
-| `onError`         | `(error: { type: 'upload'; message: string; file?: File }) => void` | Handles upload failures. When omitted, the editor displays its default error toast. | No       | None                          |
-| `resourceVideo`   | `'upload' \| 'link' \| 'both'`                                      | Controls whether users can add videos by local upload, URL, or both.                | No       | `'both'`                      |
-| `videoProviders`  | `string[]`                                                          | Restricts linked videos to matching providers. Use `['.']` to accept any URL.       | No       | `['.']`                       |
+| Option            | Type                                                                                    | Description                                                                                        | Required | Default                       |
+| ----------------- | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------- | ----------------------------- |
+| `allowFullscreen` | `boolean`                                                                               | Allows embedded videos to enter fullscreen mode.                                                   | No       | `true`                        |
+| `frameborder`     | `boolean`                                                                               | Displays a border around the embedded video frame.                                                 | No       | `false`                       |
+| `width`           | `number \| string`                                                                      | Sets the default video width.                                                                      | No       | `VIDEO_SIZE.size-medium`      |
+| `HTMLAttributes`  | `Record<string, any>`                                                                   | Adds HTML attributes to the video wrapper.                                                         | No       | `{ class: 'iframe-wrapper' }` |
+| `upload`          | `(file: File) => Promise<string>`                                                       | Uploads a local video and resolves with the URL inserted into the editor.                          | No       | None                          |
+| `multiple`        | `boolean`                                                                               | Allows selecting and uploading multiple videos.                                                    | No       | `true`                        |
+| `acceptMimes`     | `string[]`                                                                              | Restricts local files by MIME type or extension; wildcard values such as `video/*` are supported.  | No       | `['video/*']`                 |
+| `maxSize`         | `number`                                                                                | Maximum size of each local video in bytes. No size limit is applied when omitted.                  | No       | None                          |
+| `onError`         | `(error: { type: 'size' \| 'type' \| 'upload'; message: string; file?: File }) => void` | Handles validation and upload failures. When omitted, the editor displays its default error toast. | No       | None                          |
+| `resourceVideo`   | `'upload' \| 'link' \| 'both'`                                                          | Controls whether users can add videos by local upload, URL, or both.                               | No       | `'both'`                      |
+| `videoProviders`  | `string[]`                                                                              | Restricts linked videos to matching providers. Use `['.']` to accept any URL.                      | No       | `['.']`                       |
 
 ## Upload behavior
 
@@ -162,3 +177,6 @@ the returned URL is inserted into the editor and the dialog closes.
 If the promise rejects, no video is inserted. The dialog remains open so the user can retry the same
 file. Configure `onError` to provide custom error handling; otherwise, the editor shows its default
 upload error toast.
+
+`acceptMimes` and `maxSize` validate every selected file before uploading. With `multiple: true`, all
+valid files upload in parallel and are inserted in selection order after every upload succeeds.

--- a/docs/extensions/Video/index.md
+++ b/docs/extensions/Video/index.md
@@ -45,7 +45,28 @@ const extensions = [
 
   ...
   // Import Extensions Here
-  Video// [!code ++]
+  Video.configure({// [!code ++]
+    resourceVideo: 'both',// [!code ++]
+    upload: async (file) => {// [!code ++]
+      const formData = new FormData();// [!code ++]
+      formData.append('file', file);// [!code ++]
+// [!code ++]
+      const response = await fetch('/api/videos', {// [!code ++]
+        method: 'POST',// [!code ++]
+        body: formData,// [!code ++]
+      });// [!code ++]
+// [!code ++]
+      if (!response.ok) {// [!code ++]
+        throw new Error('Video upload failed');// [!code ++]
+      }// [!code ++]
+// [!code ++]
+      const { url } = await response.json();// [!code ++]
+      return url;// [!code ++]
+    },// [!code ++]
+    onError: ({ message, file }) => {// [!code ++]
+      console.error(message, file?.name);// [!code ++]
+    },// [!code ++]
+  })// [!code ++]
 ];
 
 const RichTextToolbar = () => {
@@ -103,7 +124,41 @@ interface VideoOptions extends GeneralOptions<VideoOptions> {
   /** Function for uploading files */
   upload?: (file: File) => Promise<string>;
 
+  /** Callback invoked when a video upload fails */
+  onError?: (error: { type: 'upload'; message: string; file?: File }) => void;
+
   /** The source URL of the video */
   resourceVideo: 'upload' | 'link' | 'both';
+
+  /**
+   * List of allowed video hosting providers.
+   * Use ['.'] to allow any URL.
+   *
+   * @default ['.']
+   */
+  videoProviders?: string[];
 }
 ```
+
+## Options
+
+| Option            | Type                                                                | Description                                                                         | Required | Default                       |
+| ----------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------- | ----------------------------- |
+| `allowFullscreen` | `boolean`                                                           | Allows embedded videos to enter fullscreen mode.                                    | No       | `true`                        |
+| `frameborder`     | `boolean`                                                           | Displays a border around the embedded video frame.                                  | No       | `false`                       |
+| `width`           | `number \| string`                                                  | Sets the default video width.                                                       | No       | `VIDEO_SIZE.size-medium`      |
+| `HTMLAttributes`  | `Record<string, any>`                                               | Adds HTML attributes to the video wrapper.                                          | No       | `{ class: 'iframe-wrapper' }` |
+| `upload`          | `(file: File) => Promise<string>`                                   | Uploads a local video and resolves with the URL inserted into the editor.           | No       | None                          |
+| `onError`         | `(error: { type: 'upload'; message: string; file?: File }) => void` | Handles upload failures. When omitted, the editor displays its default error toast. | No       | None                          |
+| `resourceVideo`   | `'upload' \| 'link' \| 'both'`                                      | Controls whether users can add videos by local upload, URL, or both.                | No       | `'both'`                      |
+| `videoProviders`  | `string[]`                                                          | Restricts linked videos to matching providers. Use `['.']` to accept any URL.       | No       | `['.']`                       |
+
+## Upload behavior
+
+While the `upload` promise is pending, both the toolbar dialog and the slash-command dialog stay
+open, disable the upload button, and show a localized loading indicator. When the promise resolves,
+the returned URL is inserted into the editor and the dialog closes.
+
+If the promise rejects, no video is inserted. The dialog remains open so the user can retry the same
+file. Configure `onError` to provide custom error handling; otherwise, the editor shows its default
+upload error toast.

--- a/src/components/SlashDialogTrigger/RenderDialogUploadVideo.tsx
+++ b/src/components/SlashDialogTrigger/RenderDialogUploadVideo.tsx
@@ -12,13 +12,14 @@ import {
 } from '@/components';
 import { useListener } from '@/components/ReactBus';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
-import { Video } from '@/extensions/Video/Video';
+import { DEFAULT_VIDEO_OPTIONS, Video } from '@/extensions/Video/Video';
 import { useToggleActive } from '@/hooks/useActive';
 import { useExtension } from '@/hooks/useExtension';
 import { useLocale } from '@/locales';
 import { useEditorInstance } from '@/store/editor';
 import { checkIsVideoUrl } from '@/utils/checkIsVideoUrl';
 import { EVENTS } from '@/utils/customEvents/events.constant';
+import { validateFiles } from '@/utils/validateFile';
 
 export function RenderDialogUploadVideo() {
   const { t } = useLocale();
@@ -59,25 +60,48 @@ export function RenderDialogUploadVideo() {
       event.target.value = '';
       return;
     }
-    const file = files[0];
+    const validFiles = validateFiles(Array.from(files), {
+      acceptMimes: uploadOptions.acceptMimes ?? DEFAULT_VIDEO_OPTIONS.acceptMimes,
+      maxSize: uploadOptions.maxSize ?? Number.POSITIVE_INFINITY,
+      t,
+      toast,
+      onError: uploadOptions.onError,
+    });
+
+    if (validFiles.length === 0) {
+      event.target.value = '';
+      return;
+    }
+
+    const filesToUpload =
+      (uploadOptions.multiple ?? DEFAULT_VIDEO_OPTIONS.multiple)
+        ? validFiles
+        : validFiles.slice(0, 1);
 
     setIsUploading(true);
     try {
-      let src = '';
-      if (uploadOptions.upload) {
-        src = await uploadOptions.upload(file);
-      } else {
-        src = URL.createObjectURL(file);
+      const srcs = await Promise.all(
+        filesToUpload.map((file) => {
+          return uploadOptions.upload
+            ? uploadOptions.upload(file)
+            : Promise.resolve(URL.createObjectURL(file));
+        })
+      );
+
+      if (editor.isDestroyed) {
+        return;
       }
 
-      editor
-        .chain()
-        .focus()
-        .setVideo({
-          src,
-          width: '100%',
-        })
-        .run();
+      srcs.forEach((src) => {
+        editor
+          .chain()
+          .focus()
+          .setVideo({
+            src,
+            width: '100%',
+          })
+          .run();
+      });
       setOpen(false);
     } catch (error) {
       console.error('Error uploading video', error);
@@ -85,7 +109,6 @@ export function RenderDialogUploadVideo() {
         uploadOptions.onError({
           type: 'upload',
           message: t('editor.upload.error'),
-          file,
         });
       } else {
         toast({
@@ -128,7 +151,16 @@ export function RenderDialogUploadVideo() {
   }
 
   return (
-    <Dialog onOpenChange={setOpen} open={open}>
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (isUploading && !nextOpen) {
+          return;
+        }
+
+        setOpen(nextOpen);
+      }}
+      open={open}
+    >
       <DialogContent>
         <DialogTitle>{t('editor.video.dialog.title')}</DialogTitle>
 
@@ -173,8 +205,11 @@ export function RenderDialogUploadVideo() {
             </div>
 
             <input
-              accept='video/*'
-              multiple
+              accept={
+                (uploadOptions.acceptMimes ?? DEFAULT_VIDEO_OPTIONS.acceptMimes).join(',') ||
+                'video/*'
+              }
+              multiple={uploadOptions.multiple ?? DEFAULT_VIDEO_OPTIONS.multiple}
               onChange={handleFile}
               ref={fileInput}
               type='file'

--- a/src/components/SlashDialogTrigger/RenderDialogUploadVideo.tsx
+++ b/src/components/SlashDialogTrigger/RenderDialogUploadVideo.tsx
@@ -1,6 +1,15 @@
-import { useMemo, useRef, useState } from 'react';
+import { type ChangeEvent, useMemo, useRef, useState } from 'react';
 
-import { Button, Input, Tabs, TabsContent, TabsList, TabsTrigger } from '@/components';
+import {
+  Button,
+  IconComponent,
+  Input,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  useToast,
+} from '@/components';
 import { useListener } from '@/components/ReactBus';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Video } from '@/extensions/Video/Video';
@@ -13,6 +22,7 @@ import { EVENTS } from '@/utils/customEvents/events.constant';
 
 export function RenderDialogUploadVideo() {
   const { t } = useLocale();
+  const { toast } = useToast();
 
   const editor = useEditorInstance();
   // const buttonProps = useButtonProps(Video.name);
@@ -30,6 +40,7 @@ export function RenderDialogUploadVideo() {
   const [error, setError] = useState<string>('');
 
   const [open, setOpen] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
   const extension = useExtension(Video.name);
 
   const EVENT_ID = EVENTS.UPLOAD_VIDEO((editor as any).id);
@@ -42,29 +53,50 @@ export function RenderDialogUploadVideo() {
     return uploadOptions;
   }, [extension]);
 
-  async function handleFile(event: any) {
-    const files = event?.target?.files;
-    if (!editor || editor.isDestroyed || files.length === 0) {
+  async function handleFile(event: ChangeEvent<HTMLInputElement>) {
+    const files = event.target.files;
+    if (!editor || editor.isDestroyed || !files?.length || isUploading) {
+      event.target.value = '';
       return;
     }
     const file = files[0];
 
-    let src = '';
-    if (uploadOptions.upload) {
-      src = await uploadOptions.upload(file);
-    } else {
-      src = URL.createObjectURL(file);
-    }
+    setIsUploading(true);
+    try {
+      let src = '';
+      if (uploadOptions.upload) {
+        src = await uploadOptions.upload(file);
+      } else {
+        src = URL.createObjectURL(file);
+      }
 
-    editor
-      .chain()
-      .focus()
-      .setVideo({
-        src,
-        width: '100%',
-      })
-      .run();
-    setOpen(false);
+      editor
+        .chain()
+        .focus()
+        .setVideo({
+          src,
+          width: '100%',
+        })
+        .run();
+      setOpen(false);
+    } catch (error) {
+      console.error('Error uploading video', error);
+      if (uploadOptions.onError) {
+        uploadOptions.onError({
+          type: 'upload',
+          message: t('editor.upload.error'),
+          file,
+        });
+      } else {
+        toast({
+          variant: 'destructive',
+          title: t('editor.upload.error'),
+        });
+      }
+    } finally {
+      setIsUploading(false);
+      event.target.value = '';
+    }
   }
   function handleLink(e: any) {
     e.preventDefault();
@@ -122,8 +154,21 @@ export function RenderDialogUploadVideo() {
 
           <TabsContent value='upload'>
             <div className='richtext-flex richtext-items-center richtext-gap-[10px]'>
-              <Button className='richtext-mt-1 richtext-w-full' onClick={handleClick} size='sm'>
-                {t('editor.video.dialog.tab.upload')}
+              <Button
+                className='richtext-mt-1 richtext-w-full'
+                disabled={isUploading}
+                onClick={handleClick}
+                size='sm'
+              >
+                {isUploading ? (
+                  <>
+                    {t('editor.video.dialog.uploading')}
+
+                    <IconComponent className='richtext-ml-1 richtext-animate-spin' name='Loader' />
+                  </>
+                ) : (
+                  t('editor.video.dialog.tab.upload')
+                )}
               </Button>
             </div>
 

--- a/src/extensions/Video/Video.ts
+++ b/src/extensions/Video/Video.ts
@@ -36,8 +36,17 @@ export interface VideoOptions extends GeneralOptions<VideoOptions> {
   /** Function for uploading files */
   upload?: (file: File) => Promise<string>;
 
-  /** Callback invoked when a video upload fails */
-  onError?: (error: { type: 'upload'; message: string; file?: File }) => void;
+  /** Whether multiple videos can be selected and uploaded at once */
+  multiple?: boolean;
+
+  /** Accepted video MIME types or file extensions */
+  acceptMimes?: string[];
+
+  /** Maximum size of a single video in bytes. No limit is applied when omitted. */
+  maxSize?: number;
+
+  /** Callback invoked when video validation or upload fails */
+  onError?: (error: { type: 'size' | 'type' | 'upload'; message: string; file?: File }) => void;
 
   /** The source URL of the video */
   resourceVideo: 'upload' | 'link' | 'both';
@@ -50,6 +59,13 @@ export interface VideoOptions extends GeneralOptions<VideoOptions> {
    */
   videoProviders?: string[];
 }
+
+export const DEFAULT_VIDEO_OPTIONS = {
+  acceptMimes: ['video/*'],
+  multiple: true,
+  resourceVideo: 'both',
+  videoProviders: ['.'],
+} satisfies Pick<VideoOptions, 'acceptMimes' | 'multiple' | 'resourceVideo' | 'videoProviders'>;
 
 /**
  * Represents the type for setting video options
@@ -133,8 +149,8 @@ export const Video = /* @__PURE__ */ Node.create<VideoOptions>({
       spacer: false,
       allowFullscreen: true,
       upload: undefined,
+      ...DEFAULT_VIDEO_OPTIONS,
       frameborder: false,
-      resourceVideo: 'both',
       width: VIDEO_SIZE['size-medium'],
       HTMLAttributes: {
         class: 'iframe-wrapper',
@@ -151,7 +167,7 @@ export const Video = /* @__PURE__ */ Node.create<VideoOptions>({
             disabled: !editor.can().setVideo?.({}),
             icon: 'Video',
             tooltip: t('editor.video.tooltip'),
-            videoProviders: ['.'],
+            videoProviders: DEFAULT_VIDEO_OPTIONS.videoProviders,
             editor,
           },
         };

--- a/src/extensions/Video/Video.ts
+++ b/src/extensions/Video/Video.ts
@@ -36,6 +36,9 @@ export interface VideoOptions extends GeneralOptions<VideoOptions> {
   /** Function for uploading files */
   upload?: (file: File) => Promise<string>;
 
+  /** Callback invoked when a video upload fails */
+  onError?: (error: { type: 'upload'; message: string; file?: File }) => void;
+
   /** The source URL of the video */
   resourceVideo: 'upload' | 'link' | 'both';
 

--- a/src/extensions/Video/components/RichTextVideo.tsx
+++ b/src/extensions/Video/components/RichTextVideo.tsx
@@ -12,13 +12,14 @@ import {
   useToast,
 } from '@/components';
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { Video } from '@/extensions/Video/Video';
+import { DEFAULT_VIDEO_OPTIONS, Video } from '@/extensions/Video/Video';
 import { useToggleActive } from '@/hooks/useActive';
 import { useButtonProps } from '@/hooks/useButtonProps';
 import { useExtension } from '@/hooks/useExtension';
 import { useLocale } from '@/locales';
 import { useEditorInstance } from '@/store/editor';
 import { checkIsVideoUrl } from '@/utils/checkIsVideoUrl';
+import { validateFiles } from '@/utils/validateFile';
 
 export function RichTextVideo() {
   const { t } = useLocale();
@@ -52,25 +53,48 @@ export function RichTextVideo() {
       event.target.value = '';
       return;
     }
-    const file = files[0];
+    const validFiles = validateFiles(Array.from(files), {
+      acceptMimes: uploadOptions.acceptMimes ?? DEFAULT_VIDEO_OPTIONS.acceptMimes,
+      maxSize: uploadOptions.maxSize ?? Number.POSITIVE_INFINITY,
+      t,
+      toast,
+      onError: uploadOptions.onError,
+    });
+
+    if (validFiles.length === 0) {
+      event.target.value = '';
+      return;
+    }
+
+    const filesToUpload =
+      (uploadOptions.multiple ?? DEFAULT_VIDEO_OPTIONS.multiple)
+        ? validFiles
+        : validFiles.slice(0, 1);
 
     setIsUploading(true);
     try {
-      let src = '';
-      if (uploadOptions.upload) {
-        src = await uploadOptions.upload(file);
-      } else {
-        src = URL.createObjectURL(file);
+      const srcs = await Promise.all(
+        filesToUpload.map((file) => {
+          return uploadOptions.upload
+            ? uploadOptions.upload(file)
+            : Promise.resolve(URL.createObjectURL(file));
+        })
+      );
+
+      if (editor.isDestroyed) {
+        return;
       }
 
-      editor
-        .chain()
-        .focus()
-        .setVideo({
-          src,
-          width: '100%',
-        })
-        .run();
+      srcs.forEach((src) => {
+        editor
+          .chain()
+          .focus()
+          .setVideo({
+            src,
+            width: '100%',
+          })
+          .run();
+      });
       setOpen(false);
     } catch (error) {
       console.error('Error uploading video', error);
@@ -78,7 +102,6 @@ export function RichTextVideo() {
         uploadOptions.onError({
           type: 'upload',
           message: t('editor.upload.error'),
-          file,
         });
       } else {
         toast({
@@ -117,7 +140,16 @@ export function RichTextVideo() {
   }
 
   return (
-    <Dialog onOpenChange={setOpen} open={open}>
+    <Dialog
+      onOpenChange={(nextOpen) => {
+        if (isUploading && !nextOpen) {
+          return;
+        }
+
+        setOpen(nextOpen);
+      }}
+      open={open}
+    >
       <DialogTrigger asChild>
         <ActionButton
           disabled={editorDisabled}
@@ -174,8 +206,11 @@ export function RichTextVideo() {
             </div>
 
             <input
-              accept='video/*'
-              multiple
+              accept={
+                (uploadOptions.acceptMimes ?? DEFAULT_VIDEO_OPTIONS.acceptMimes).join(',') ||
+                'video/*'
+              }
+              multiple={uploadOptions.multiple ?? DEFAULT_VIDEO_OPTIONS.multiple}
               onChange={handleFile}
               ref={fileInput}
               type='file'

--- a/src/extensions/Video/components/RichTextVideo.tsx
+++ b/src/extensions/Video/components/RichTextVideo.tsx
@@ -1,13 +1,15 @@
-import { useMemo, useRef, useState } from 'react';
+import { type ChangeEvent, useMemo, useRef, useState } from 'react';
 
 import {
   ActionButton,
   Button,
+  IconComponent,
   Input,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  useToast,
 } from '@/components';
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Video } from '@/extensions/Video/Video';
@@ -20,6 +22,7 @@ import { checkIsVideoUrl } from '@/utils/checkIsVideoUrl';
 
 export function RichTextVideo() {
   const { t } = useLocale();
+  const { toast } = useToast();
 
   const editor = useEditorInstance();
   const buttonProps = useButtonProps(Video.name);
@@ -34,6 +37,7 @@ export function RichTextVideo() {
   const [error, setError] = useState<string>('');
 
   const [open, setOpen] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
   const extension = useExtension(Video.name);
 
   const uploadOptions = useMemo(() => {
@@ -42,29 +46,50 @@ export function RichTextVideo() {
     return uploadOptions;
   }, [extension]);
 
-  async function handleFile(event: any) {
-    const files = event?.target?.files;
-    if (!editor || editor.isDestroyed || files.length === 0) {
+  async function handleFile(event: ChangeEvent<HTMLInputElement>) {
+    const files = event.target.files;
+    if (!editor || editor.isDestroyed || !files?.length || isUploading) {
+      event.target.value = '';
       return;
     }
     const file = files[0];
 
-    let src = '';
-    if (uploadOptions.upload) {
-      src = await uploadOptions.upload(file);
-    } else {
-      src = URL.createObjectURL(file);
-    }
+    setIsUploading(true);
+    try {
+      let src = '';
+      if (uploadOptions.upload) {
+        src = await uploadOptions.upload(file);
+      } else {
+        src = URL.createObjectURL(file);
+      }
 
-    editor
-      .chain()
-      .focus()
-      .setVideo({
-        src,
-        width: '100%',
-      })
-      .run();
-    setOpen(false);
+      editor
+        .chain()
+        .focus()
+        .setVideo({
+          src,
+          width: '100%',
+        })
+        .run();
+      setOpen(false);
+    } catch (error) {
+      console.error('Error uploading video', error);
+      if (uploadOptions.onError) {
+        uploadOptions.onError({
+          type: 'upload',
+          message: t('editor.upload.error'),
+          file,
+        });
+      } else {
+        toast({
+          variant: 'destructive',
+          title: t('editor.upload.error'),
+        });
+      }
+    } finally {
+      setIsUploading(false);
+      event.target.value = '';
+    }
   }
   function handleLink(e: any) {
     e.preventDefault();
@@ -130,8 +155,21 @@ export function RichTextVideo() {
 
           <TabsContent value='upload'>
             <div className='richtext-flex richtext-items-center richtext-gap-[10px]'>
-              <Button className='richtext-mt-1 richtext-w-full' onClick={handleClick} size='sm'>
-                {t('editor.video.dialog.tab.upload')}
+              <Button
+                className='richtext-mt-1 richtext-w-full'
+                disabled={isUploading}
+                onClick={handleClick}
+                size='sm'
+              >
+                {isUploading ? (
+                  <>
+                    {t('editor.video.dialog.uploading')}
+
+                    <IconComponent className='richtext-ml-1 richtext-animate-spin' name='Loader' />
+                  </>
+                ) : (
+                  t('editor.video.dialog.tab.upload')
+                )}
               </Button>
             </div>
 


### PR DESCRIPTION
## Summary

- add a loading state while videos are being uploaded
- prevent duplicate submissions during upload
- support file type and size validation
- support single and multiple video uploads
- handle upload failures and allow retrying the same file
- document the video upload options and behavior

## New options

- `acceptMimes`
- `maxSize`
- `multiple`
- `onError`

## Validation

- `pnpm lint`
- `pnpm type-check`
- `pnpm build:lib`
- VitePress documentation build
- `git diff --check`

Closes #369