### PR TITLE
fix: preserve percentage image widths after reload

### DIFF
--- a/src/extensions/Image/Image.ts
+++ b/src/extensions/Image/Image.ts
@@ -49,6 +49,15 @@ function getBooleanHTMLAttribute(value: string | boolean | null | undefined): bo
   return parseBooleanHTMLAttribute(value) ?? false;
 }
 
+function parseImageWidth(width: string | null): number | string | null {
+  if (!width) {
+    return null;
+  }
+
+  const normalizedWidth = width.trim();
+  return normalizedWidth.endsWith('%') ? normalizedWidth : Number.parseInt(normalizedWidth, 10);
+}
+
 function getImageElement(element: HTMLElement): HTMLImageElement | null {
   if (element.matches('img')) {
     return element as HTMLImageElement;
@@ -73,7 +82,7 @@ function getImageAttrsFromElement(element: HTMLElement, inlineFallback = false) 
     src: img.getAttribute('src'),
     alt: img.getAttribute('alt'),
     caption: img.getAttribute('caption'),
-    width: width ? Number.parseInt(width, 10) : null,
+    width: parseImageWidth(width),
     align: img.getAttribute('align') || element.style.textAlign || null,
     inline,
     flipX: flipX === 'true',
@@ -233,7 +242,7 @@ export const ImageBlock = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
         default: null,
         parseHTML: (element) => {
           const width = element.style.width || element.getAttribute('width') || null;
-          return !width ? null : Number.parseInt(width, 10);
+          return parseImageWidth(width);
         },
         renderHTML: (attributes) => {
           return {
@@ -411,7 +420,7 @@ export const Image = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
         default: null,
         parseHTML: (element) => {
           const width = element.style.width || element.getAttribute('width') || null;
-          return !width ? null : Number.parseInt(width, 10);
+          return parseImageWidth(width);
         },
         renderHTML: (attributes) => {
           return {


### PR DESCRIPTION
## Summary

- Preserve percentage-based image widths when parsing HTML.
- Apply the same width parsing behavior to inline and block image nodes.
- Keep the existing behavior for pixel and numeric widths unchanged.

## Problem

Image widths such as `100%` were parsed with `Number.parseInt`, which converted them to `100`. After reloading the document, this numeric value was rendered as `100px`, causing percentage-sized images to shrink unexpectedly.

## Changes

Added a shared image width parser that:

- preserves percentage widths as strings, such as `100%`
- parses pixel and numeric widths as numbers, such as `500px` to `500`
- returns `null` when no width is provided

The parser is now used by all HTML parsing paths for both `Image` and `ImageBlock`.

## Validation

- Verified that `100%` remains `100%` for inline and block images after reloading.
- Verified that `500px` continues to parse as `500`.
- Passed `pnpm type-check`.
- Passed `pnpm build:lib`.
- Passed `git diff --check`.

Fixes #147