### PR TITLE
fix: preserve GIF size after reload

### DIFF
--- a/src/extensions/ImageGif/ImageGif.ts
+++ b/src/extensions/ImageGif/ImageGif.ts
@@ -88,8 +88,8 @@ export const ImageGif = /* @__PURE__ */ TiptapImage.extend<ImageGifOptions>({
       width: {
         default: null,
         parseHTML: (element) => {
-          const width = element.style.width || element.getAttribute('width') || '10';
-          return width === undefined ? null : Number.parseInt(`${width}`, 10);
+          const width = element.style.width || element.getAttribute('width');
+          return width ? Number.parseInt(width, 10) : null;
         },
         renderHTML: (attributes) => {
           return {


### PR DESCRIPTION
## Summary

- Remove the implicit 10px fallback when parsing GIF widths.
- Preserve the natural GIF size when reloading HTML without an explicit width.
- Keep the existing parsing behavior for explicitly configured widths.

## Problem

When an `ImageGif` node was loaded from HTML without a `width` style or attribute, the width parser defaulted to `10`. The node view then rendered that value as `10px`, causing the GIF to become extremely small after the editor content was reloaded.

## Changes

- Read the GIF width only from its existing style or HTML attribute.
- Return `null` when no width is provided instead of defaulting to `10`.
- Continue parsing explicit pixel and numeric widths as numbers.

## Validation

- Verified that a GIF without a width parses to `null`.
- Verified that an explicit `width="480"` continues to parse as `480`.
- Verified that `style="width: 320px"` continues to parse as `320`.
- Passed formatting checks.
- Passed targeted lint checks.
- Passed `pnpm type-check`.
- Passed `pnpm build:lib`.
- Passed `git diff --check`.

Fixes #205