### PR TITLE
fix: support mobile drag gestures

### DIFF
--- a/src/extensions/Image/components/ImageView.tsx
+++ b/src/extensions/Image/components/ImageView.tsx
@@ -1,6 +1,6 @@
 import { NodeViewWrapper } from '@tiptap/react';
 import { clamp, isNumber, throttle } from 'lodash-es';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { IMAGE_MAX_SIZE, IMAGE_MIN_SIZE, IMAGE_THROTTLE_WAIT_TIME } from '@/constants';
 
@@ -17,6 +17,8 @@ const ResizeDirection = {
 };
 
 function ImageView(props: any) {
+  const { updateAttributes } = props;
+
   const [maxSize, setMaxSize] = useState<Size>({
     width: IMAGE_MAX_SIZE,
     height: IMAGE_MAX_SIZE,
@@ -36,13 +38,12 @@ function ImageView(props: any) {
 
   const [resizing, setResizing] = useState<boolean>(false);
 
-  const [resizerState, setResizerState] = useState({
-    x: 0,
-    y: 0,
-    w: 0,
-    h: 0,
-    dir: '',
-  });
+  const resizeSession = useRef<{
+    pointerId: number;
+    x: number;
+    width: number;
+    direction: string;
+  } | null>(null);
 
   const { align, inline } = props?.node?.attrs;
   const isBlockNode = props?.node?.type?.name === 'imageBlock';
@@ -109,10 +110,13 @@ function ImageView(props: any) {
     [props?.editor]
   );
 
-  function onMouseDown(e: MouseEvent, dir: string) {
+  function onPointerDown(e: React.PointerEvent<HTMLSpanElement>, dir: string) {
+    if (!e.isPrimary || (e.pointerType === 'mouse' && e.button !== 0)) {
+      return;
+    }
+
     e.preventDefault();
     e.stopPropagation();
-
     const originalWidth = originalSize.width;
     const originalHeight = originalSize.height;
     const aspectRatio = originalWidth / originalHeight;
@@ -134,85 +138,74 @@ function ImageView(props: any) {
       width = width > maxWidth ? maxWidth : width;
     }
 
-    setResizing(true);
-
-    setResizerState({
+    resizeSession.current = {
+      pointerId: e.pointerId,
       x: e.clientX,
-      y: e.clientY,
-      w: width,
-      h: height,
-      dir,
-    });
+      width,
+      direction: dir,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    setResizing(true);
   }
 
-  const onMouseMove = useCallback(
-    throttle((e: MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
+  const resizeToPointer = useMemo(
+    () =>
+      throttle((clientX: number, pointerId: number) => {
+        const session = resizeSession.current;
+        if (!session || session.pointerId !== pointerId) {
+          return;
+        }
 
-      if (!resizing) {
-        return;
-      }
+        const dx = (clientX - session.x) * (/l/.test(session.direction) ? -1 : 1);
+        const width = clamp(session.width + dx, IMAGE_MIN_SIZE, maxSize.width);
 
-      const { x, w, dir } = resizerState;
-
-      const dx = (e.clientX - x) * (/l/.test(dir) ? -1 : 1);
-      // const dy = (e.clientY - y) * (/t/.test(dir) ? -1 : 1)
-
-      const width = clamp(w + dx, IMAGE_MIN_SIZE, maxSize.width);
-      const height = null;
-
-      props.updateAttributes({
-        width,
-        height,
-      });
-    }, IMAGE_THROTTLE_WAIT_TIME),
-    [resizing, resizerState, maxSize, props.updateAttributes]
+        updateAttributes({
+          width,
+          height: null,
+        });
+      }, IMAGE_THROTTLE_WAIT_TIME),
+    [maxSize.width, updateAttributes]
   );
 
-  const onMouseUp = useCallback(
-    (e: MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (!resizing) {
-        return;
-      }
-
-      setResizerState({
-        x: 0,
-        y: 0,
-        w: 0,
-        h: 0,
-        dir: '',
-      });
-      setResizing(false);
-
-      selectImage();
-    },
-    [resizing, selectImage]
-  );
-
-  const onEvents = useCallback(() => {
-    document?.addEventListener('mousemove', onMouseMove, true);
-    document?.addEventListener('mouseup', onMouseUp, true);
-  }, [onMouseMove, onMouseUp]);
-
-  const offEvents = useCallback(() => {
-    document?.removeEventListener('mousemove', onMouseMove, true);
-    document?.removeEventListener('mouseup', onMouseUp, true);
-  }, [onMouseMove, onMouseUp]);
-
-  useEffect(() => {
-    if (resizing) {
-      onEvents();
-    } else {
-      offEvents();
+  function onPointerMove(e: React.PointerEvent<HTMLSpanElement>) {
+    if (resizeSession.current?.pointerId !== e.pointerId) {
+      return;
     }
 
+    e.preventDefault();
+    e.stopPropagation();
+    resizeToPointer(e.clientX, e.pointerId);
+  }
+
+  function finishResize(e: React.PointerEvent<HTMLSpanElement>, updateFinalPosition: boolean) {
+    if (resizeSession.current?.pointerId !== e.pointerId) {
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (updateFinalPosition) {
+      resizeToPointer(e.clientX, e.pointerId);
+      resizeToPointer.flush();
+    } else {
+      resizeToPointer.cancel();
+    }
+
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+
+    resizeSession.current = null;
+    setResizing(false);
+    selectImage();
+  }
+
+  useEffect(() => {
     return () => {
-      offEvents();
+      resizeToPointer.cancel();
     };
-  }, [resizing, onEvents, offEvents]);
+  }, [resizeToPointer]);
 
   const resizeOb: ResizeObserver = useMemo(() => {
     return new ResizeObserver(() => getMaxSize());
@@ -264,7 +257,10 @@ function ImageView(props: any) {
                 <span
                   className={`image-resizer__handler image-resizer__handler--${direction}`}
                   key={`image-dir-${direction}`}
-                  onMouseDown={(e: any) => onMouseDown(e, direction)}
+                  onPointerCancel={(e) => finishResize(e, false)}
+                  onPointerDown={(e) => onPointerDown(e, direction)}
+                  onPointerMove={onPointerMove}
+                  onPointerUp={(e) => finishResize(e, true)}
                 ></span>
               );
             })}

--- a/src/extensions/ImageGif/components/ImageGifView.tsx
+++ b/src/extensions/ImageGif/components/ImageGifView.tsx
@@ -1,6 +1,6 @@
 import { NodeViewWrapper } from '@tiptap/react';
 import { clamp, isNumber, throttle } from 'lodash-es';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { IMAGE_MAX_SIZE, IMAGE_MIN_SIZE, IMAGE_THROTTLE_WAIT_TIME } from '@/constants';
 
@@ -17,6 +17,8 @@ const ResizeDirection = {
 };
 
 function ImageGifView(props: any) {
+  const { updateAttributes } = props;
+
   const [maxSize, setMaxSize] = useState<Size>({
     width: IMAGE_MAX_SIZE,
     height: IMAGE_MAX_SIZE,
@@ -36,13 +38,12 @@ function ImageGifView(props: any) {
 
   const [resizing, setResizing] = useState<boolean>(false);
 
-  const [resizerState, setResizerState] = useState({
-    x: 0,
-    y: 0,
-    w: 0,
-    h: 0,
-    dir: '',
-  });
+  const resizeSession = useRef<{
+    pointerId: number;
+    x: number;
+    width: number;
+    direction: string;
+  } | null>(null);
 
   const { align } = props?.node?.attrs;
 
@@ -96,10 +97,13 @@ function ImageGifView(props: any) {
     [props?.editor]
   );
 
-  function onMouseDown(e: MouseEvent, dir: string) {
+  function onPointerDown(e: React.PointerEvent<HTMLSpanElement>, dir: string) {
+    if (!e.isPrimary || (e.pointerType === 'mouse' && e.button !== 0)) {
+      return;
+    }
+
     e.preventDefault();
     e.stopPropagation();
-
     const originalWidth = originalSize.width;
     const originalHeight = originalSize.height;
     const aspectRatio = originalWidth / originalHeight;
@@ -121,85 +125,74 @@ function ImageGifView(props: any) {
       width = width > maxWidth ? maxWidth : width;
     }
 
-    setResizing(true);
-
-    setResizerState({
+    resizeSession.current = {
+      pointerId: e.pointerId,
       x: e.clientX,
-      y: e.clientY,
-      w: width,
-      h: height,
-      dir,
-    });
+      width,
+      direction: dir,
+    };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    setResizing(true);
   }
 
-  const onMouseMove = useCallback(
-    throttle((e: MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
+  const resizeToPointer = useMemo(
+    () =>
+      throttle((clientX: number, pointerId: number) => {
+        const session = resizeSession.current;
+        if (!session || session.pointerId !== pointerId) {
+          return;
+        }
 
-      if (!resizing) {
-        return;
-      }
+        const dx = (clientX - session.x) * (/l/.test(session.direction) ? -1 : 1);
+        const width = clamp(session.width + dx, IMAGE_MIN_SIZE, maxSize.width);
 
-      const { x, w, dir } = resizerState;
-
-      const dx = (e.clientX - x) * (/l/.test(dir) ? -1 : 1);
-      // const dy = (e.clientY - y) * (/t/.test(dir) ? -1 : 1)
-
-      const width = clamp(w + dx, IMAGE_MIN_SIZE, maxSize.width);
-      const height = null;
-
-      props.updateAttributes({
-        width,
-        height,
-      });
-    }, IMAGE_THROTTLE_WAIT_TIME),
-    [resizing, resizerState, maxSize, props.updateAttributes]
+        updateAttributes({
+          width,
+          height: null,
+        });
+      }, IMAGE_THROTTLE_WAIT_TIME),
+    [maxSize.width, updateAttributes]
   );
 
-  const onMouseUp = useCallback(
-    (e: MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      if (!resizing) {
-        return;
-      }
-
-      setResizerState({
-        x: 0,
-        y: 0,
-        w: 0,
-        h: 0,
-        dir: '',
-      });
-      setResizing(false);
-
-      selectImage();
-    },
-    [resizing, selectImage]
-  );
-
-  const onEvents = useCallback(() => {
-    document?.addEventListener('mousemove', onMouseMove, true);
-    document?.addEventListener('mouseup', onMouseUp, true);
-  }, [onMouseMove, onMouseUp]);
-
-  const offEvents = useCallback(() => {
-    document?.removeEventListener('mousemove', onMouseMove, true);
-    document?.removeEventListener('mouseup', onMouseUp, true);
-  }, [onMouseMove, onMouseUp]);
-
-  useEffect(() => {
-    if (resizing) {
-      onEvents();
-    } else {
-      offEvents();
+  function onPointerMove(e: React.PointerEvent<HTMLSpanElement>) {
+    if (resizeSession.current?.pointerId !== e.pointerId) {
+      return;
     }
 
+    e.preventDefault();
+    e.stopPropagation();
+    resizeToPointer(e.clientX, e.pointerId);
+  }
+
+  function finishResize(e: React.PointerEvent<HTMLSpanElement>, updateFinalPosition: boolean) {
+    if (resizeSession.current?.pointerId !== e.pointerId) {
+      return;
+    }
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (updateFinalPosition) {
+      resizeToPointer(e.clientX, e.pointerId);
+      resizeToPointer.flush();
+    } else {
+      resizeToPointer.cancel();
+    }
+
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    }
+
+    resizeSession.current = null;
+    setResizing(false);
+    selectImage();
+  }
+
+  useEffect(() => {
     return () => {
-      offEvents();
+      resizeToPointer.cancel();
     };
-  }, [resizing, onEvents, offEvents]);
+  }, [resizeToPointer]);
 
   const resizeOb: ResizeObserver = useMemo(() => {
     return new ResizeObserver(() => getMaxSize());
@@ -243,7 +236,10 @@ function ImageGifView(props: any) {
                 <span
                   className={`image-resizer__handler image-resizer__handler--${direction}`}
                   key={`image-dir-${direction}`}
-                  onMouseDown={(e: any) => onMouseDown(e, direction)}
+                  onPointerCancel={(e) => finishResize(e, false)}
+                  onPointerDown={(e) => onPointerDown(e, direction)}
+                  onPointerMove={onPointerMove}
+                  onPointerUp={(e) => finishResize(e, true)}
                 ></span>
               );
             })}

--- a/src/extensions/Table/components/CreateTablePopover.tsx
+++ b/src/extensions/Table/components/CreateTablePopover.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import { Popover, PopoverContent, PopoverTrigger } from '@/components';
 import {
@@ -23,6 +23,7 @@ interface GridSize {
 
 function CreateTablePopover(props: IPropsCreateTablePopover) {
   const [open, setOpen] = useState(false);
+  const activePointerId = useRef<number | null>(null);
 
   const [withHeaderRow, setWithHeaderRow] = useState<boolean>(true);
   const [tableGridSize, setTableGridSize] = useState<GridSize>({
@@ -34,6 +35,7 @@ function CreateTablePopover(props: IPropsCreateTablePopover) {
     rows: TABLE_DEFAULT_SELECTED_GRID_SIZE,
     cols: TABLE_DEFAULT_SELECTED_GRID_SIZE,
   });
+  const selectedTableGridSizeRef = useRef(selectedTableGridSize);
 
   function selectTableGridSize(rows: number, cols: number): void {
     if (rows === tableGridSize.rows) {
@@ -54,16 +56,106 @@ function CreateTablePopover(props: IPropsCreateTablePopover) {
       });
     }
 
-    setSelectedTableGridSize({
+    const nextGridSize = {
       rows,
       cols,
-    });
+    };
+    selectedTableGridSizeRef.current = nextGridSize;
+    setSelectedTableGridSize(nextGridSize);
   }
 
-  function onMouseDown(rows: number, cols: number) {
+  function createSelectedTable() {
+    const { rows, cols } = selectedTableGridSizeRef.current;
     props?.createTable({ rows, cols, withHeaderRow });
     resetTableGridSize();
     setOpen(false);
+  }
+
+  function getGridCell(event: React.PointerEvent<HTMLDivElement>): HTMLElement | null {
+    const directTarget =
+      event.target instanceof Element
+        ? event.target.closest<HTMLElement>('[data-table-grid-cell]')
+        : null;
+
+    if (directTarget) {
+      return directTarget;
+    }
+
+    const elementAtPointer = document.elementFromPoint(event.clientX, event.clientY);
+    return elementAtPointer?.closest<HTMLElement>('[data-table-grid-cell]') ?? null;
+  }
+
+  function selectGridCellFromPointer(event: React.PointerEvent<HTMLDivElement>): boolean {
+    const gridCell = getGridCell(event);
+    if (!gridCell || !event.currentTarget.contains(gridCell)) {
+      return false;
+    }
+
+    const rows = Number(gridCell.dataset.rows);
+    const cols = Number(gridCell.dataset.cols);
+    if (Number.isNaN(rows) || Number.isNaN(cols)) {
+      return false;
+    }
+
+    selectTableGridSize(rows, cols);
+    return true;
+  }
+
+  function onPointerDown(event: React.PointerEvent<HTMLDivElement>) {
+    if (!event.isPrimary || (event.pointerType === 'mouse' && event.button !== 0)) {
+      return;
+    }
+
+    if (!selectGridCellFromPointer(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    activePointerId.current = event.pointerId;
+    event.currentTarget.setPointerCapture(event.pointerId);
+  }
+
+  function onPointerMove(event: React.PointerEvent<HTMLDivElement>) {
+    if (activePointerId.current !== null && activePointerId.current !== event.pointerId) {
+      return;
+    }
+
+    if (activePointerId.current !== null) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
+    selectGridCellFromPointer(event);
+  }
+
+  function onPointerUp(event: React.PointerEvent<HTMLDivElement>) {
+    if (activePointerId.current !== event.pointerId) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    selectGridCellFromPointer(event);
+
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+
+    activePointerId.current = null;
+    createSelectedTable();
+  }
+
+  function onPointerCancel(event: React.PointerEvent<HTMLDivElement>) {
+    if (activePointerId.current !== event.pointerId) {
+      return;
+    }
+
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+
+    activePointerId.current = null;
   }
 
   function resetTableGridSize(): void {
@@ -74,10 +166,12 @@ function CreateTablePopover(props: IPropsCreateTablePopover) {
       cols: TABLE_INIT_GRID_SIZE,
     });
 
-    setSelectedTableGridSize({
+    const defaultSelectedGridSize = {
       rows: TABLE_DEFAULT_SELECTED_GRID_SIZE,
       cols: TABLE_DEFAULT_SELECTED_GRID_SIZE,
-    });
+    };
+    selectedTableGridSizeRef.current = defaultSelectedGridSize;
+    setSelectedTableGridSize(defaultSelectedGridSize);
   }
 
   return (
@@ -88,16 +182,24 @@ function CreateTablePopover(props: IPropsCreateTablePopover) {
 
       <PopoverContent align='start' className='richtext-w-full !richtext-p-2' side='bottom'>
         <div className='table-grid-size-editor richtext-p-0'>
-          <div className='richtext-flex richtext-flex-col richtext-flex-wrap richtext-justify-between richtext-gap-1'>
+          <div
+            className='richtext-flex richtext-flex-col richtext-flex-wrap richtext-justify-between richtext-gap-1'
+            onPointerCancel={onPointerCancel}
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={onPointerUp}
+            style={{ touchAction: 'none' }}
+          >
             {createArray(tableGridSize?.rows)?.map((row: any) => {
               return (
                 <div className='richtext-flex richtext-gap-1' key={`richtext-table-row-${row}`}>
                   {createArray(tableGridSize?.cols)?.map((col: any) => {
                     return (
                       <div
+                        data-cols={col}
+                        data-rows={row}
+                        data-table-grid-cell
                         key={`richtext-table-col-${col}`}
-                        onMouseDown={() => onMouseDown(row, col)}
-                        onMouseOver={() => selectTableGridSize(row, col)}
                         className={`richtext-cursor-pointer richtext-border-border ${
                           col <= selectedTableGridSize.cols &&
                           row <= selectedTableGridSize.rows &&

--- a/src/styles/editor.scss
+++ b/src/styles/editor.scss
@@ -199,6 +199,8 @@
         z-index: 2;
         box-sizing: border-box;
         display: block;
+        touch-action: none;
+        user-select: none;
         width: 12px;
         height: 12px;
         border: 1px solid #fff;


### PR DESCRIPTION
## Summary

- replace mouse-only image and GIF resize handling with Pointer Events
- use pointer capture to keep resizing active when a touch or pointer moves outside the resize handle
- support touch drag selection in the table size picker while preserving desktop hover behavior
- prevent browser scrolling from interrupting resize and table selection gestures

## Root cause

The image and GIF resize handles only listened for mouse events, and the table size picker relied on mouse hover and mouse down events. These interactions therefore did not work correctly on touch devices.

## Video behavior

The current video extension no longer provides drag resize handles. Video width is adjusted through the existing S/M/L controls in the bubble menu, which are already usable on touch devices. This PR keeps that interaction unchanged.

## Validation

- TypeScript type check
- lint for the modified files
- formatting check for the modified files
- library production build
- playground production build
- verified compatibility with the latest GIF size persistence changes from PR #373

Closes #115