### PR TITLE
fix: restore broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Thanks to the following friends for their contributions to project:
 
 ## Star History
 
-<img src="https://api.star-history.com/svg?repos=hunghg255/reactjs-tiptap-editor" />
+<img src="https://star-history.dera.page/svg?repos=hunghg255/reactjs-tiptap-editor" />
 
 ## Related
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer displays, since the old provider is affected by GitHub stargazer API restrictions. This change points the chart to a working provider so visitors can see the project's star history again.