### PR TITLE
fix(image): drop empty paragraphs around legacy block image markup

### DIFF
--- a/docs/extensions/Image/index.md
+++ b/docs/extensions/Image/index.md
@@ -61,6 +61,7 @@ The example starts in URL-only mode so it works without a backend. To enable loc
 Existing HTML is still accepted:
 
 - `<div class="image"><img ... /></div>` is parsed as `imageBlock`.
+- `<p><div class="image"><img inline="false" ... /></div></p>` produced by versions before 1.0.26 is parsed as `imageBlock` without the empty paragraphs the browser adds around it, so the document no longer grows on each save/load.
 - `<span class="image"><img inline="true" ... /></span>` is parsed as the inline `image` node.
 - Old JSON with `type: "image"` continues to load. If you want to migrate stored JSON, use `migrateImageJSONToImageBlock(json)` before saving the migrated document.
 

--- a/src/extensions/Image/Image.ts
+++ b/src/extensions/Image/Image.ts
@@ -91,6 +91,31 @@ function getImageAttrsFromElement(element: HTMLElement, inlineFallback = false) 
   };
 }
 
+/**
+ * Versions before 1.0.26 rendered block images as `<p><div class="image"><img inline="false"></div></p>`.
+ * The browser HTML parser closes the `<p>` before the `<div>`, leaving an empty
+ * paragraph on each side of the image. Those legacy wrappers are identified by the
+ * `inline="false"` attribute, which the current renderer no longer emits.
+ */
+function isLegacyBlockImageWrapper(element: Element | null): boolean {
+  return (
+    !!element &&
+    element.matches('div.image') &&
+    element.querySelector('img')?.getAttribute('inline') === 'false'
+  );
+}
+
+function isEmptyParagraphNextToLegacyBlockImage(element: HTMLElement): boolean {
+  if (element.childElementCount > 0 || element.textContent?.trim()) {
+    return false;
+  }
+
+  return (
+    isLegacyBlockImageWrapper(element.previousElementSibling) ||
+    isLegacyBlockImageWrapper(element.nextElementSibling)
+  );
+}
+
 function getTransformStyle(flipX: boolean, flipY: boolean): string {
   return flipX || flipY
     ? `transform: rotateX(${flipX ? '180' : '0'}deg) rotateY(${flipY ? '180' : '0'}deg);`
@@ -320,6 +345,14 @@ export const ImageBlock = /* @__PURE__ */ TiptapImage.extend<IImageOptions>({
   },
   parseHTML() {
     return [
+      {
+        // Drop the empty paragraphs the browser creates around legacy `<p><div class="image">` markup.
+        tag: 'p',
+        priority: 51,
+        ignore: true,
+        getAttrs: (element) =>
+          isEmptyParagraphNextToLegacyBlockImage(element as HTMLElement) ? null : false,
+      },
       {
         tag: 'div[class=image]',
         getAttrs: (element) => {


### PR DESCRIPTION
Versions before 1.0.26 rendered block images as `<p><div class="image">…</div></p>`. The browser HTML parser closes the `<p>` before the `<div>`, so loading that content produced an empty paragraph on each side of the image. Add a parse rule to `imageBlock` that ignores an empty `<p>` adjacent to a legacy wrapper (identified by `img[inline="false"]`, which the current renderer no longer emits). Content produced by the current version is unaffected.

Closes #102


Claude-Session: https://claude.ai/code/session_01DvQoAJVoY5bwQmwL8Yi8NU