### PR TITLE
fix(export-pdf): keep columns side by side and stop relying on CDN st…

### DIFF
--- a/.claude/skills/gh-issue/SKILL.md
+++ b/.claude/skills/gh-issue/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: gh-issue
+description: "Work GitHub issues of this repo (hunghg255/reactjs-tiptap-editor) with the gh CLI: list open issues, show one issue with its comments parsed by the repo's issue-form template (affected extension, reproduction, editor content, expected/actual, version), and fix a chosen issue on a dedicated branch with lint/type-check verification and a `Closes #N` commit. Use when the user says 'list issues', 'show issue 123', 'fix issue 123', 'fix #123', 'issue nào đang mở', 'sửa issue', 'gh issue', or asks what bugs are reported on GitHub."
+argument-hint: "[list [--all] [--label X] [--limit N] | show <N> | fix <N>]"
+---
+
+IRON LAW: NEVER FIX FROM THE TITLE. Read the full issue body AND every comment, locate the code, then present a plan and get a "go" before editing. Never `git push` or open a PR without explicit approval.
+
+## gh CLI resolution
+
+`gh` may not be on PATH in this shell. Resolve it once per session:
+
+```bash
+GH="$(command -v gh || echo "/c/Program Files/GitHub CLI/gh.exe")"
+"$GH" auth status || echo "NOT LOGGED IN"
+```
+
+If not logged in, stop and tell the user to run:
+`! & "C:\Program Files\GitHub CLI\gh.exe" auth login -h github.com -p https -w`
+
+Repo is inferred from `origin`; no `-R` flag needed when cwd is the repo.
+
+## Sub-commands
+
+No argument → `list`.
+
+### list
+
+```bash
+"$GH" issue list --state open --limit 30 --json number,title,labels,createdAt,comments,author \
+  --template '{{range .}}#{{.number}}	{{.title}}	[{{range .labels}}{{.name}} {{end}}]	{{.author.login}}	{{timeago .createdAt}}	💬{{len .comments}}{{"\n"}}{{end}}'
+```
+
+- `--all` → `--state all`; `--label X` → `--label X`; `--limit N` overrides 30.
+- Print as a markdown table: `#`, Title, Labels, Author, Age, Comments. Newest first (default).
+- End with: "Bảo tôi `fix <N>` để sửa issue nào." (reply in the user's language).
+
+### show <N>
+
+```bash
+"$GH" issue view N --comments
+```
+
+Parse the body with the template map below, then summarize: what is reported, affected extension(s), repro (link + steps + content), expected vs actual, version, clarifications in comments, linked PRs. Flag if the issue is closed, has a linked open PR, or is missing required template fields (pre-template issue or edited away).
+
+## Issue template fields
+
+Issues are created through `.github/ISSUE_TEMPLATE/*.yml` (blank issues disabled). GitHub renders each form field as a `### <Label>` heading followed by its value (`_No response_` when empty). Locate fields by heading, never by position.
+
+**Bug report** (`[Bug]: …`, label `bug`):
+
+| Heading | Field | How to use it |
+|---|---|---|
+| `### Bug description` | what breaks | Problem statement for the plan |
+| `### Affected extension(s)` | comma-separated dropdown values | Start in `src/extensions/<Name>/`. `Core (...)` → `src/components/`, `src/store/`; `Bubble menus` → `src/components/Bubble/`, `src/bubble.ts`; `Locale / i18n` → `src/locale*.ts`, `src/locales/`; `Theme / styles` → `src/styles/`, `src/theme/`; `Bundle size / lazy loading` → `src/components/LazyContent.tsx`, `tests/bundle-*`; `Types / TypeScript` → `src/types.ts`, `tests/public-types.test.ts`; `Not sure` → derive from steps/content |
+| `### Reproduction link` | StackBlitz/CodeSandbox/repo URL | Open it in the browser when the code path isn't obvious |
+| `### Steps to reproduce` | numbered steps | Replay them in the playground (`pnpm playground`, `window.editor` is exposed) |
+| `### Editor content that triggers the bug` | fenced `html` block | Use verbatim as the fixture: `editor.commands.setContent(...)`, compare `getHTML()`/`getJSON()` before and after the fix |
+| `### Expected behavior` / `### Actual behavior` | | The pass/fail criterion for verification — quote both in the final report |
+| `### reactjs-tiptap-editor version` | semver | If older than `package.json`, run `git log v<version>..HEAD -- src/extensions/<Name>` — it may already be fixed; say so and stop |
+| `### Environment` | fenced `shell` block | React/Tiptap/browser versions — check for upstream `@tiptap/*` mismatch |
+| `### Validations` | checkboxes | `[x] I would like to submit a PR` → tell the user before fixing; the reporter may be working on it |
+
+**Feature request** (`[Feature]: …`, label `enhancement`): `### Problem`, `### Proposed solution`, `### Related extension(s)` (`New extension` → scaffold under `src/extensions/<Name>/` following an existing one, e.g. `Callout/`), `### Alternatives considered`, `### Additional context`, `### Validations`. `fix` on a feature request means implement it — plan must include the public API (exports in `src/index.ts`, `package.json` `exports`, docs page under `docs/extensions/<Name>/`).
+
+**Legacy issue** (no `###` headings): fall back to free-form reading; extract the same facts and note which are missing.
+
+### fix <N>
+
+Copy this checklist and check off items as you go:
+
+```
+Fix #N Progress:
+- [ ] 1. Read issue + all comments (`issue view N --comments`) ⚠️ REQUIRED
+- [ ] 2. Preflight: `git status` clean, on `main`, `git pull --ff-only`
+- [ ] 3. Locate the code (start from `Affected extension(s)`, else grep src/ for names in steps/content)
+- [ ] 4. Reproduce or confirm root cause by reading the code path
+- [ ] 5. Present plan → wait for "go" ⛔ BLOCKING
+- [ ] 6. Branch: `git checkout -b fix/issue-N-<short-slug>`
+- [ ] 7. Implement the minimal fix
+- [ ] 8. Verify: `pnpm lint` && `pnpm type-check` (+ relevant tests below)
+- [ ] 9. Commit with `Closes #N`
+- [ ] 10. Ask before push / PR ⛔ BLOCKING
+```
+
+**Step 3–4 questions to answer before planning:**
+- Which extension/component owns this behavior? (`Affected extension(s)` first; verify — reporters guess.)
+- Is it a bug in this repo, or in an upstream `@tiptap/*` package (`Environment` block vs. `node_modules/@tiptap/*`)?
+- Does it still reproduce on `main` with the issue's `Editor content` / steps? (`git log v<version>..HEAD` — if already fixed, say so and stop.)
+- Is the *output* invalid HTML (e.g. block element inside `<p>`)? Then the browser parser, not ProseMirror, is what mangles it on reload — check `renderHTML` first.
+
+**Step 5 plan format** (short — 5–10 lines):
+- Root cause (file:line)
+- Change to make
+- Files touched
+- How it will be verified
+Then stop and wait.
+
+**Step 8 verification** — always `pnpm lint` and `pnpm type-check`. Additionally:
+- Public API/types changed → `pnpm test:types`
+- Word/locale/KaTeX/bundle-loading touched → run the matching `tests/*.test.ts` via `pnpm exec esno --test <file>` (see `tests/README.md`)
+- Visual/interaction bug → `pnpm playground` and check in browser when asked
+Report results verbatim; if anything fails, fix or say so — don't commit red.
+
+**Step 9 commit** — conventional commit, scope = extension/component name, body references the issue:
+
+```
+fix(<scope>): <what changed>
+
+<why, 1–3 lines>
+
+Closes #N
+```
+
+Use `/ai-git-commit` if the user prefers the bot identity; otherwise `/git-commit`.
+
+**Step 10** — ask: push branch? open PR with `"$GH" pr create --fill --body "Closes #N"`? Do neither without a yes.
+
+## Anti-patterns
+
+- Fixing from the title/first paragraph without reading comments (maintainer often narrows the bug there)
+- Trusting `Affected extension(s)` without verifying — it is the reporter's guess
+- Skipping the `Editor content` fixture and inventing your own repro
+- Editing on `main` instead of a `fix/issue-N-*` branch
+- Broad refactors while fixing — keep the diff scoped to the issue
+- Committing when lint/type-check is red
+- Running `gh issue close`/`comment` on the user's behalf without being asked
+- Guessing the repo with `-R` — rely on `origin`
+
+## Pre-delivery checklist (fix)
+
+- [ ] Diff touches only files named in the approved plan (or explained deviations)
+- [ ] `pnpm lint` and `pnpm type-check` output shown, both green
+- [ ] Commit message contains `Closes #N`
+- [ ] Branch name is `fix/issue-N-<slug>`, `main` untouched
+- [ ] User told what was NOT done (e.g., not pushed, PR not opened)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,157 @@
+name: 🐛 Bug report
+description: Something is broken in reactjs-tiptap-editor
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! Please fill in every required field — issues without a reproduction are hard to act on and may be closed.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug description
+      description: What is happening? Include error messages or screenshots if any.
+      placeholder: Empty paragraphs are added around the image element when loading content...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: extension
+    attributes:
+      label: Affected extension(s)
+      description: Pick the extension(s) involved. Choose "Not sure" if you don't know.
+      multiple: true
+      options:
+        - Not sure
+        - Core (RichTextProvider / EditorContent / Toolbar)
+        - Bubble menus
+        - Locale / i18n
+        - Theme / styles
+        - Bundle size / lazy loading
+        - Types / TypeScript
+          - AI
+          - Attachment
+          - Blockquote
+          - Bold
+          - BulletList
+          - Callout
+          - Clear
+          - Code
+          - CodeBlock
+          - CodeView
+          - Color
+          - Column
+          - Drawer
+          - Emoji
+          - Excalidraw
+          - ExportPdf
+          - ExportWord
+          - FontFamily
+          - FontSize
+          - FormatPainter
+          - Heading
+          - Highlight
+          - History
+          - HorizontalRule
+          - Iframe
+          - Image
+          - ImageGif
+          - ImportWord
+          - Indent
+          - Italic
+          - Katex
+          - LineHeight
+          - Link
+          - MarkdownPaste
+          - Mention
+          - Mermaid
+          - MoreMark
+          - OrderedList
+          - SearchAndReplace
+          - ShortMessage
+          - SlashCommand
+          - Strike
+          - Table
+          - TaskList
+          - TextAlign
+          - TextDirection
+          - TextUnderline
+          - Twitter
+          - Video
+    validations:
+      required: true
+
+  - type: input
+    id: reproduction
+    attributes:
+      label: Reproduction link
+      description: A minimal repro on StackBlitz / CodeSandbox / a public repo. Fork the playground if that helps.
+      placeholder: https://stackblitz.com/edit/...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Set content to '...'
+        2. Click '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: content
+    attributes:
+      label: Editor content that triggers the bug
+      description: The HTML / JSON passed to the editor, if relevant. Rendered as HTML.
+      render: html
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happens, including the actual output HTML/JSON if it differs.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: reactjs-tiptap-editor version
+      description: Run `npm ls reactjs-tiptap-editor`.
+      placeholder: 1.0.41
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Output of `npx envinfo --system --binaries --browsers --npmPackages react,react-dom,@tiptap/core,@tiptap/react`
+      render: shell
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Validations
+      options:
+        - label: I have searched existing issues and this is not a duplicate.
+          required: true
+        - label: I have reproduced this on the latest version of reactjs-tiptap-editor.
+          required: true
+        - label: I have read the documentation and this is not a usage question.
+          required: true
+        - label: I would like to submit a PR for this.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://reactjs-tiptap-editor.vercel.app/
+    about: Check the docs first — setup, extension options and examples.
+  - name: 💬 Questions & Discussions
+    url: https://github.com/hunghg255/reactjs-tiptap-editor/discussions
+    about: Ask usage questions or share ideas here instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,105 @@
+name: ✨ Feature request
+description: Suggest a new extension, option or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What are you trying to do that is hard or impossible today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the API / behavior you'd like. Code examples are welcome.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: extension
+    attributes:
+      label: Related extension(s)
+      description: Which extension does this belong to? Choose "New extension" for something new.
+      multiple: true
+      options:
+        - New extension
+        - Core (RichTextProvider / EditorContent / Toolbar)
+        - Bubble menus
+        - Locale / i18n
+        - Theme / styles
+          - AI
+          - Attachment
+          - Blockquote
+          - Bold
+          - BulletList
+          - Callout
+          - Clear
+          - Code
+          - CodeBlock
+          - CodeView
+          - Color
+          - Column
+          - Drawer
+          - Emoji
+          - Excalidraw
+          - ExportPdf
+          - ExportWord
+          - FontFamily
+          - FontSize
+          - FormatPainter
+          - Heading
+          - Highlight
+          - History
+          - HorizontalRule
+          - Iframe
+          - Image
+          - ImageGif
+          - ImportWord
+          - Indent
+          - Italic
+          - Katex
+          - LineHeight
+          - Link
+          - MarkdownPaste
+          - Mention
+          - Mermaid
+          - MoreMark
+          - OrderedList
+          - SearchAndReplace
+          - ShortMessage
+          - SlashCommand
+          - Strike
+          - Table
+          - TaskList
+          - TextAlign
+          - TextDirection
+          - TextUnderline
+          - Twitter
+          - Video
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you tried, or how other editors solve this.
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Links, screenshots, references.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Validations
+      options:
+        - label: I have searched existing issues and discussions and this is not a duplicate.
+          required: true
+        - label: I would like to submit a PR for this.

--- a/src/utils/pdf.ts
+++ b/src/utils/pdf.ts
@@ -2,6 +2,52 @@ import { type ExportPdfOptions } from '@/extensions/ExportPdf';
 
 import type { Editor } from '@tiptap/core';
 
+const CDN_STYLESHEET = 'https://cdn.jsdelivr.net/npm/reactjs-tiptap-editor@latest/lib/style.css';
+
+/**
+ * Minimal layout rules that must hold even if no external stylesheet loads
+ * (offline, CSP, CDN blocked). Keeps multi-column content side by side
+ * instead of collapsing into stacked blocks (see issue #177).
+ */
+const FALLBACK_PRINT_STYLES = `
+  .columns {
+    display: flex;
+    width: 100%;
+    gap: 8px;
+    margin-top: 0.75em;
+  }
+  .columns .column {
+    flex: 1 1 0%;
+    min-width: 0;
+    padding: 12px;
+    border: 1px solid #e5e7eb;
+    border-radius: 2px;
+    box-sizing: border-box;
+  }
+  .columns .column p:first-of-type {
+    margin-top: 0;
+  }
+`;
+
+/**
+ * Collect the stylesheets already loaded by the host page (the app imports
+ * `reactjs-tiptap-editor/style.css`), so the print document uses the exact
+ * same CSS version without depending on the network.
+ */
+function collectHostStyles(): string {
+  if (typeof document === 'undefined') return '';
+
+  return Array.from(document.querySelectorAll<HTMLElement>('style, link[rel="stylesheet"]'))
+    .map((el) => {
+      if (el instanceof HTMLLinkElement) {
+        // skip browser-extension / non-web sheets that cannot load inside the iframe
+        return /^https?:/.test(el.href) ? `<link rel="stylesheet" href="${el.href}">` : '';
+      }
+      return `<style>${el.textContent ?? ''}</style>`;
+    })
+    .join('\n');
+}
+
 function printHtml(content: string, exportPdfOptions: ExportPdfOptions) {
   const iframe: HTMLIFrameElement = document.createElement('iframe');
   iframe.setAttribute('style', 'position: absolute; width: 0; height: 0; top: 0; left: 0;');
@@ -24,7 +70,11 @@ function printHtml(content: string, exportPdfOptions: ExportPdfOptions) {
       <title>${title}</title>
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      ${collectHostStyles()}
+      <link rel="stylesheet" href="${CDN_STYLESHEET}">
       <style>
+        ${FALLBACK_PRINT_STYLES}
+
         @media print {
           @page {
             size: ${paperSize};
@@ -35,6 +85,8 @@ function printHtml(content: string, exportPdfOptions: ExportPdfOptions) {
             background: none;
             margin: 0;
             padding: 0;
+            -webkit-print-color-adjust: exact;
+            print-color-adjust: exact;
           }
 
           .print-container {
@@ -42,16 +94,22 @@ function printHtml(content: string, exportPdfOptions: ExportPdfOptions) {
             box-sizing: border-box;
           }
 
+          .print-container .ProseMirror.ProseMirror.ProseMirror {
+            padding: 0;
+            min-height: 0;
+          }
+
           .no-print {
             display: none;
           }
         }
       </style>
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reactjs-tiptap-editor@latest/lib/style.css">
     </head>
     <body>
-      <div class="print-container">
-        ${content}
+      <div class="print-container reactjs-tiptap-editor">
+        <div class="ProseMirror">
+          ${content}
+        </div>
       </div>
     </body>
     </html>


### PR DESCRIPTION
…yles

Reuse the host page's stylesheets in the print iframe, add an inline
fallback for `.columns/.column` layout, and wrap the content in
`.reactjs-tiptap-editor .ProseMirror` so scoped editor styles apply
when printing. Previously the print document was unstyled whenever the
CDN sheet could not load, collapsing columns into stacked blocks.

Closes #177

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ULtZwt9SDVAdTVt539UESR